### PR TITLE
feat/add changelog template

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,42 @@
+{{ if .Versions -}}
+<a name="unreleased"></a>
+## [Unreleased]
+
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -15,10 +15,17 @@
 {{ range .Versions }}
 <a name="{{ .Tag.Name }}"></a>
 ## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+
+{{ if .CommitGroups -}}
 {{ range .CommitGroups -}}
 ### {{ .Title }}
 {{ range .Commits -}}
 - {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ else }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{if .Subject}}{{ .Subject }}{{else if .Header}}{{ .Header }}{{ end }}
 {{ end }}
 {{ end -}}
 

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -14,7 +14,7 @@ options:
         - refactor
   commit_groups:
     title_maps:
-      feat: Addeed
+      feat: Added
       fix: Fixed
       remove: Removed
       deprecate: Deprecated

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -5,20 +5,20 @@ info:
   repository_url: https://github.com/jonataslaw/get
 options:
   commits:
-    # filters:
-    #   Type:
-    #     - feat
-    #     - fix
-    #     - remove
-    #     - deprecate
-    #     - refactor
+    filters:
+      Type:
+        - feat
+        - fix
+        - remove
+        - deprecate
+        - refactor
   commit_groups:
-    # title_maps:
-    #   feat: Addeed
-    #   fix: Fixed
-    #   remove: Removed
-    #   deprecate: Deprecated
-    #   refactor: Changed
+    title_maps:
+      feat: Addeed
+      fix: Fixed
+      remove: Removed
+      deprecate: Deprecated
+      refactor: Changed
   header:
     pattern: "^(\\w*)\\:\\s(.*)$"
     pattern_maps:

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,29 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/jonataslaw/get
+options:
+  commits:
+    # filters:
+    #   Type:
+    #     - feat
+    #     - fix
+    #     - remove
+    #     - deprecate
+    #     - refactor
+  commit_groups:
+    # title_maps:
+    #   feat: Addeed
+    #   fix: Fixed
+    #   remove: Removed
+    #   deprecate: Deprecated
+    #   refactor: Changed
+  header:
+    pattern: "^(\\w*)\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE


### PR DESCRIPTION
This assumes that you are tagging releases and generating the CHANGELOG using https://github.com/git-chglog/git-chglog.

By default, commits that don't follow conventional commits syntax would be discluded. In order to include previous commits, I modified the template.

Running `git-chglog --next-tag 2.0.8` produces the following output.  

```
<a name="unreleased"></a>
## [Unreleased]


<a name="2.0.8"></a>
## [2.0.8] - 2020-04-28

### Added
- update changelog template to include non-conventional commits
- support for kac changelog format, conventional commits

### Fixed
- spelling error in config

<a name="2.0.0"></a>
## [2.0.0] - 2020-04-27


- Update README.md
- update readme
- Release Get 2.0
- Update README.md


<a name="1.20.1"></a>
## [1.20.1] - 2020-04-21


- Update README.pt-br.md
- improve Get.find
- Add files via upload
- Update issue templates
- Update issue templates
- Update issue templates
- Update issue templates
- Update issue templates
- Add files via upload
- New release of Get
- change version of stable branch
- Add files via upload
- added Get.config - added LogEnable/disable - added default transition - added overlayContext - added default popGesture behaviour - fix Duration transition
- Update README.md
- Update README.md
- Update README.md
- Refactor GetRoute to add back gesture


<a name="1.13.1"></a>
## [1.13.1] - 2020-03-30


- new release
- Update routes.dart
- Compatibility with dev/master branch
- Update README.md


<a name="1.11.1"></a>
## [1.11.1] - 2020-03-04


- Add files via upload
- Update README.md
- Add files via upload
- Add files via upload
- Update README.md
- Update snack_route.dart
- release new version
- Merge pull request [#11](https://github.com/jonataslaw/get/issues/11) from claudneysessa/patch-1
- static snackbar -> add backgroundColor
- Update routes.dart
- Update README.md
- Update README.md


<a name="1.7.0"></a>
## [1.7.0] - 2020-01-30


- New release
- Update README.md
- Add files via upload
- Update README.md
- Update routes.dart
- Update README.md
- Update README.md
- Update README.md
- Update README.md
- Update getroute.dart
- Update README.md
- Update README.md
- Update README.md


<a name="1.2.1"></a>
## 1.2.1 - 2019-11-15


- Add files via upload
- Delete get.dart
- Delete routes.dart
- Delete material.dart
- Add files via upload
- Initial commit


[Unreleased]: https://github.com/jonataslaw/get/compare/2.0.8...HEAD
[2.0.8]: https://github.com/jonataslaw/get/compare/2.0.0...2.0.8
[2.0.0]: https://github.com/jonataslaw/get/compare/1.20.1...2.0.0
[1.20.1]: https://github.com/jonataslaw/get/compare/1.13.1...1.20.1
[1.13.1]: https://github.com/jonataslaw/get/compare/1.11.1...1.13.1
[1.11.1]: https://github.com/jonataslaw/get/compare/1.7.0...1.11.1
[1.7.0]: https://github.com/jonataslaw/get/compare/1.2.1...1.7.0
```

Unfortunately, because some commit messages were less descriptive, they don't capture what's in the changelog now.  For an example of how I use this package, check out https://github.com/chimon2000/remote_state/blob/master/scripts/prepare_release.sh

* Update package version 
* Pipe new version into `git-chglog`
* Replace CHANGELOG with output