### PR TITLE
Typo in isEmail

### DIFF
--- a/lib/src/regex/get_utils.dart
+++ b/lib/src/regex/get_utils.dart
@@ -78,7 +78,7 @@ class GetUtils {
   static bool isURL(String s) => RegexValidation.hasMatch(s, regex.url);
 
   /// Checks if string is email.
-  static bool isEmail(String s) => RegexValidation.hasMatch(s, regex.txt);
+  static bool isEmail(String s) => RegexValidation.hasMatch(s, regex.email);
 
   /// Checks if string is phone number.
   static bool isPhoneNumber(String s) =>


### PR DESCRIPTION
There was a small typo in the `isEmail` utility function.