### PR TITLE
get_instance.dart redundant ternary

### DIFF
--- a/lib/src/instance/get_instance.dart
+++ b/lib/src/instance/get_instance.dart
@@ -227,11 +227,7 @@ class GetInstance {
 
     FcBuilder builder = GetConfig._singl[newKey] as FcBuilder;
     if (builder.permanent) {
-      (key == null)
-          ? print(
-              '[GET] [$newKey] has been marked as permanent, SmartManagement is not authorized to delete it.')
-          : print(
-              '[GET] [$newKey] has been marked as permanent, SmartManagement is not authorized to delete it.');
+      print('[GET] [$newKey] has been marked as permanent, SmartManagement is not authorized to delete it.');
       return false;
     }
     final i = builder.dependency;


### PR DESCRIPTION
The ternary on the line ~222 it is a redundant ternary. Another possibility would be if the key is not null print it, instead of $ newKey