### PR TITLE
[docs] fix typos

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -288,67 +288,72 @@ GetPlatform.isWeb
 Get.height
 Get.width
 
-// If you need a changeable height/width (like browser windows that can be scaled) you will need to use context.
-Get.context.width
-Get.context.height
-
 // Gives the context of the screen in the foreground anywhere in your code.
 Get.context
 
 // Gives the context of the snackbar/dialog/bottomsheet in the foreground anywhere in your code.
 Get.contextOverlay
 
+// Note: the following methods are extensions on context. Since you
+// have access to context in any place of your UI, you can use it anywhere in the UI code
+
+// If you need a changeable height/width (like browser windows that can be scaled) you will need to use context.
+context.width
+context.height
+
+
+
 // gives you the power to define half the screen now, a third of it and so on.
 //Useful for responsive applications.
 // param dividedBy (double) optional - default: 1
 // param reducedBy (double) optional - default: 0
-Get.context.heightTransformer()
-Get.context.widthTransformer()
+context.heightTransformer()
+context.widthTransformer()
 
 /// similar to MediaQuery.of(context).size
-Get.context.mediaQuerySize()
+context.mediaQuerySize()
 
 /// similar to MediaQuery.of(context).padding
-Get.context.mediaQueryPadding()
+context.mediaQueryPadding()
 
 /// similar to MediaQuery.of(context).viewPadding
-Get.context.mediaQueryViewPadding()
+context.mediaQueryViewPadding()
 
 /// similar to MediaQuery.of(context).viewInsets;
-Get.context.mediaQueryViewInsets()
+context.mediaQueryViewInsets()
 
 /// similar to MediaQuery.of(context).orientation;
-Get.context.orientation()
+context.orientation()
 
 /// check if device is on landscape mode
-Get.context.isLandscape()
+context.isLandscape()
 
 /// check if device is on portrait mode
-Get.context.isPortrait()
+context.isPortrait()
 
 /// similar to MediaQuery.of(context).devicePixelRatio;
-Get.context.devicePixelRatio()
+context.devicePixelRatio()
 
 /// similar to MediaQuery.of(context).textScaleFactor;
-Get.context.textScaleFactor()
+context.textScaleFactor()
 
 /// get the shortestSide from screen
-Get.context.mediaQueryShortestSide()
+context.mediaQueryShortestSide()
 
 /// True if width be larger than 800
-Get.context.showNavbar()
+context.showNavbar()
 
 /// True if the shortestSide is smaller than 600p
-Get.context.isPhone()
+context.isPhone()
 
 /// True if the shortestSide is largest than 600p
-Get.context.isSmallTablet()
+context.isSmallTablet()
 
 /// True if the shortestSide is largest than 720p
-Get.context.isLargeTablet()
+context.isLargeTablet()
 
 /// True if the current device is Tablet
-Get.context.isTablet()
+context.isTablet()
 ```
 
 ### Configuraciones globales opcionales

--- a/README.md
+++ b/README.md
@@ -319,60 +319,60 @@ Get.context
 Get.contextOverlay
 
 // If you need a changeable height/width (like browser windows that can be scaled) you will need to use context.
-context.width
-context.height
+Get.context.width
+Get.context.height
 
 // gives you the power to define half the screen now, a third of it and so on.
 //Useful for responsive applications.
 // param dividedBy (double) optional - default: 1
 // param reducedBy (double) optional - default: 0
-context.heightTransformer()
-context.widthTransformer()
+Get.context.heightTransformer()
+Get.context.widthTransformer()
 
 /// similar to MediaQuery.of(context).size
-context.mediaQuerySize()
+Get.context.mediaQuerySize()
 
 /// similar to MediaQuery.of(context).padding
-context.mediaQueryPadding()
+Get.context.mediaQueryPadding()
 
 /// similar to MediaQuery.of(context).viewPadding
-context.mediaQueryViewPadding()
+Get.context.mediaQueryViewPadding()
 
 /// similar to MediaQuery.of(context).viewInsets;
-context.mediaQueryViewInsets()
+Get.context.mediaQueryViewInsets()
 
 /// similar to MediaQuery.of(context).orientation;
-context.orientation()
+Get.context.orientation()
 
 /// check if device is on landscape mode
-context.isLandscape()
+Get.context.isLandscape()
 
 /// check if device is on portrait mode
-context.isPortrait()
+Get.context.isPortrait()
 
 /// similar to MediaQuery.of(context).devicePixelRatio;
-context.devicePixelRatio()
+Get.context.devicePixelRatio()
 
 /// similar to MediaQuery.of(context).textScaleFactor;
-context.textScaleFactor()
+Get.context.textScaleFactor()
 
 /// get the shortestSide from screen
-context.mediaQueryShortestSide()
+Get.context.mediaQueryShortestSide()
 
 /// True if width be larger than 800
-context.showNavbar()
+Get.context.showNavbar()
 
 /// True if the shortestSide is smaller than 600p
-context.isPhone()
+Get.context.isPhone()
 
 /// True if the shortestSide is largest than 600p
-context.isSmallTablet()
+Get.context.isSmallTablet()
 
 /// True if the shortestSide is largest than 720p
-context.isLargeTablet()
+Get.context.isLargeTablet()
 
 /// True if the current device is Tablet
-context.isTablet()
+Get.context.isTablet()
 ```
 
 ### Optional Global Settings and Manual configurations

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Get.contextOverlay
 // If you need a changeable height/width (like browser windows that can be scaled) you will need to use context.
 context.width
 context.height
-
+ 
 // gives you the power to define half the screen now, a third of it and so on.
 //Useful for responsive applications.
 // param dividedBy (double) optional - default: 1

--- a/README.md
+++ b/README.md
@@ -318,61 +318,64 @@ Get.context
 // Gives the context of the snackbar/dialog/bottomsheet in the foreground anywhere in your code.
 Get.contextOverlay
 
+// Note: the following methods are extensions on context. Since you
+// have access to context in any place of your UI, you can use it anywhere in the UI code
+
 // If you need a changeable height/width (like browser windows that can be scaled) you will need to use context.
-Get.context.width
-Get.context.height
+context.width
+context.height
 
 // gives you the power to define half the screen now, a third of it and so on.
 //Useful for responsive applications.
 // param dividedBy (double) optional - default: 1
 // param reducedBy (double) optional - default: 0
-Get.context.heightTransformer()
-Get.context.widthTransformer()
+context.heightTransformer()
+context.widthTransformer()
 
 /// similar to MediaQuery.of(context).size
-Get.context.mediaQuerySize()
+context.mediaQuerySize()
 
 /// similar to MediaQuery.of(context).padding
-Get.context.mediaQueryPadding()
+context.mediaQueryPadding()
 
 /// similar to MediaQuery.of(context).viewPadding
-Get.context.mediaQueryViewPadding()
+context.mediaQueryViewPadding()
 
 /// similar to MediaQuery.of(context).viewInsets;
-Get.context.mediaQueryViewInsets()
+context.mediaQueryViewInsets()
 
 /// similar to MediaQuery.of(context).orientation;
-Get.context.orientation()
+context.orientation()
 
 /// check if device is on landscape mode
-Get.context.isLandscape()
+context.isLandscape()
 
 /// check if device is on portrait mode
-Get.context.isPortrait()
+context.isPortrait()
 
 /// similar to MediaQuery.of(context).devicePixelRatio;
-Get.context.devicePixelRatio()
+context.devicePixelRatio()
 
 /// similar to MediaQuery.of(context).textScaleFactor;
-Get.context.textScaleFactor()
+context.textScaleFactor()
 
 /// get the shortestSide from screen
-Get.context.mediaQueryShortestSide()
+context.mediaQueryShortestSide()
 
 /// True if width be larger than 800
-Get.context.showNavbar()
+context.showNavbar()
 
 /// True if the shortestSide is smaller than 600p
-Get.context.isPhone()
+context.isPhone()
 
 /// True if the shortestSide is largest than 600p
-Get.context.isSmallTablet()
+context.isSmallTablet()
 
 /// True if the shortestSide is largest than 720p
-Get.context.isLargeTablet()
+context.isLargeTablet()
 
 /// True if the current device is Tablet
-Get.context.isTablet()
+context.isTablet()
 ```
 
 ### Optional Global Settings and Manual configurations

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -299,7 +299,9 @@ Get.offNamedUntil()
 // retorna qual é a plataforma
 //(Esse método é completamente compatível com o FlutterWeb,
 //diferente do método do framework "Platform.isAndroid")
-GetPlatform.isAndroid/isIOS/isWeb...
+GetPlatform.isAndroid
+GetPlatform.isIOS
+GetPlatform.isWeb
 
 // Equivalente ao método: MediaQuery.of(context).size.width ou height, mas é imutável. Significa que não irá atualizar mesmo que o tamanho da tela mude (como em navegadores ou app desktop)
 Get.height
@@ -308,54 +310,57 @@ Get.width
 // fornece o context da tela em qualquer lugar do seu código.
 Get.context
 
-// Se você precisa de um width/height adaptável (como em navegadores em que a janela pode ser redimensionada) você precisa usar 'context'
-Get.context.width
-Get.context.height
-
 // fornece o context de snackbar/dialog/bottomsheet em qualquer lugar do seu código.
 Get.contextOverlay
 
+// Obs: os métodos a seguir são extensions do context. Já que se
+// tem acesso ao context em qualquer lugar do código da UI, você pode usar lá
+
+// Se você precisa de um width/height adaptável (como em navegadores em que a janela pode ser redimensionada) você precisa usar 'context'
+context.width
+context.height
+
 /// similar to MediaQuery.of(this).padding
-Get.context.mediaQueryPadding()
+context.mediaQueryPadding()
 
 /// similar to MediaQuery.of(this).viewPadding
-Get.context.mediaQueryViewPadding()
+context.mediaQueryViewPadding()
 
 /// similar to MediaQuery.of(this).viewInsets;
-Get.context.mediaQueryViewInsets()
+context.mediaQueryViewInsets()
 
 /// similar to MediaQuery.of(this).orientation;
-Get.context.orientation()
+context.orientation()
 
 /// check if device is on landscape mode
-Get.context.isLandscape()
+context.isLandscape()
 
 /// check if device is on portrait mode
-Get.context.isPortrait()
+context.isPortrait()
 
 /// similar to MediaQuery.of(this).devicePixelRatio;
-Get.context.devicePixelRatio()
+context.devicePixelRatio()
 
 /// similar to MediaQuery.of(this).textScaleFactor;
-Get.context.textScaleFactor()
+context.textScaleFactor()
 
 /// get the shortestSide from screen
-Get.context.mediaQueryShortestSide()
+context.mediaQueryShortestSide()
 
 /// True if width be larger than 800
-Get.context.showNavbar()
+context.showNavbar()
 
 /// True if the shortestSide is smaller than 600p
-Get.context.isPhone()
+context.isPhone()
 
 /// True if the shortestSide is largest than 600p
-Get.context.isSmallTablet()
+context.isSmallTablet()
 
 /// True if the shortestSide is largest than 720p
-Get.context.isLargeTablet()
+context.isLargeTablet()
 
 /// True if the current device is Tablet
-Get.context.isTablet()
+context.isTablet()
 ```
 
 ### Configurações Globais opcionais e configurações manuais

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -305,57 +305,57 @@ GetPlatform.isAndroid/isIOS/isWeb...
 Get.height
 Get.width
 
+// fornece o context da tela em qualquer lugar do seu código.
+Get.context
+
 // Se você precisa de um width/height adaptável (como em navegadores em que a janela pode ser redimensionada) você precisa usar 'context'
 Get.context.width
 Get.context.height
-
-// forncece o context da tela em qualquer lugar do seu código.
-Get.context
 
 // fornece o context de snackbar/dialog/bottomsheet em qualquer lugar do seu código.
 Get.contextOverlay
 
 /// similar to MediaQuery.of(this).padding
-Get.mediaQueryPadding()
+Get.context.mediaQueryPadding()
 
 /// similar to MediaQuery.of(this).viewPadding
-Get.mediaQueryViewPadding()
+Get.context.mediaQueryViewPadding()
 
 /// similar to MediaQuery.of(this).viewInsets;
-Get.mediaQueryViewInsets()
+Get.context.mediaQueryViewInsets()
 
 /// similar to MediaQuery.of(this).orientation;
-Get.orientation()
+Get.context.orientation()
 
 /// check if device is on landscape mode
-Get.isLandscape()
+Get.context.isLandscape()
 
 /// check if device is on portrait mode
-Get.isPortrait()
+Get.context.isPortrait()
 
 /// similar to MediaQuery.of(this).devicePixelRatio;
-Get.devicePixelRatio()
+Get.context.devicePixelRatio()
 
 /// similar to MediaQuery.of(this).textScaleFactor;
-Get.textScaleFactor()
+Get.context.textScaleFactor()
 
 /// get the shortestSide from screen
-Get.mediaQueryShortestSide()
+Get.context.mediaQueryShortestSide()
 
 /// True if width be larger than 800
-Get.showNavbar()
+Get.context.showNavbar()
 
 /// True if the shortestSide is smaller than 600p
-Get.isPhone()
+Get.context.isPhone()
 
 /// True if the shortestSide is largest than 600p
-Get.isSmallTablet()
+Get.context.isSmallTablet()
 
 /// True if the shortestSide is largest than 720p
-Get.isLargeTablet()
+Get.context.isLargeTablet()
 
 /// True if the current device is Tablet
-Get.isTablet()
+Get.context.isTablet()
 ```
 
 ### Configurações Globais opcionais e configurações manuais


### PR DESCRIPTION
Hello!

Somehow i managed to leave that unnoticed when i was changing that part
on the english readme it was missing `Get` before some methods
one the ptbr readme it was missing the `context` you have to put.
strangely on the spanish one is correct... very weird

anyway, just small typos