### PR TITLE
Translation return null value when no entry found

### DIFF
--- a/lib/src/get_main.dart
+++ b/lib/src/get_main.dart
@@ -655,6 +655,16 @@ class GetImpl implements GetService {
     translations.addAll(tr);
   }
 
+  void appendTranslations(Map<String, Map<String, String>> tr) {
+    tr.forEach((key, map) {
+      if (Get.translations.containsKey(key)) {
+        Get.translations[key].addAll(map);
+      } else {
+        Get.translations[key] = map;
+      }
+    });
+  }
+
   void changeTheme(ThemeData theme) {
     getxController.setTheme(theme);
   }

--- a/lib/src/root/root_widget.dart
+++ b/lib/src/root/root_widget.dart
@@ -258,14 +258,15 @@ abstract class Translations {
 extension Trans on String {
   String get tr {
     if (Get.locale?.languageCode == null) return this;
-    if (Get.translations
-        .containsKey("${Get.locale.languageCode}_${Get.locale.countryCode}")) {
+    if (Get.translations.containsKey(
+            "${Get.locale.languageCode}_${Get.locale.countryCode}") &&
+        Get.translations["${Get.locale.languageCode}_${Get.locale.countryCode}"]
+            .containsKey(this)) {
       return Get.translations[
           "${Get.locale.languageCode}_${Get.locale.countryCode}"][this];
-    } else if (Get.translations.containsKey(Get.locale.languageCode)) {
+    } else if (Get.translations.containsKey(Get.locale.languageCode) &&
+        Get.translations[Get.locale.languageCode].containsKey(this)) {
       return Get.translations[Get.locale.languageCode][this];
-    } else if (Get.translations.isNotEmpty) {
-      return Get.translations.values.first[this];
     } else {
       return this;
     }

--- a/lib/src/root/root_widget.dart
+++ b/lib/src/root/root_widget.dart
@@ -257,16 +257,22 @@ abstract class Translations {
 
 extension Trans on String {
   String get tr {
+    // Returns the key if locale is null.
     if (Get.locale?.languageCode == null) return this;
+    
+    // Checks whether the language code and country code are present, and whether the key is also present.
     if (Get.translations.containsKey(
             "${Get.locale.languageCode}_${Get.locale.countryCode}") &&
         Get.translations["${Get.locale.languageCode}_${Get.locale.countryCode}"]
             .containsKey(this)) {
       return Get.translations[
           "${Get.locale.languageCode}_${Get.locale.countryCode}"][this];
+    
+    // Checks if there is a callback language in the absence of the specific country, and if it contains that key.  
     } else if (Get.translations.containsKey(Get.locale.languageCode) &&
         Get.translations[Get.locale.languageCode].containsKey(this)) {
       return Get.translations[Get.locale.languageCode][this];
+    // If there is no corresponding language or corresponding key, return the key.
     } else {
       return this;
     }


### PR DESCRIPTION
There are 2 changes in this PR:
1. A new method appendTranslations. 
   Reason: I have a shared package with all the common widgets for several projects. In this package I will add the translations into Get. However, the translations will be replaced by the project with addTranslations.

 2. Fixed to prevent return null value if there is no translation found, by checking the key existence explicitly. Also remove the "use the first language code values" if no such language code is added into translations. I think simply return the original value would be more making sense. Hope this is fine for you.