### PR TITLE
fallbackLocale for translation (as GetMaterialApp config)

### DIFF
--- a/lib/src/get_interface.dart
+++ b/lib/src/get_interface.dart
@@ -33,6 +33,8 @@ abstract class GetInterface {
   GetMaterialController getxController = GetMaterialController();
 
   Locale locale;
+  
+  Locale fallbackLocale;
 
   GlobalKey<NavigatorState> key = GlobalKey<NavigatorState>();
 

--- a/lib/src/navigation/root/root_widget.dart
+++ b/lib/src/navigation/root/root_widget.dart
@@ -1,4 +1,4 @@
-iimport 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:get/src/instance/get_instance.dart';
@@ -240,7 +240,6 @@ class GetMaterialApp extends StatelessWidget {
             darkTheme: darkTheme,
             themeMode: _.themeMode ?? themeMode ?? ThemeMode.system,
             locale: Get.locale ?? locale,
-            fallbackLocale: Get.fallbackLocale ?? fallbackLocale,
             localizationsDelegates: localizationsDelegates,
             localeListResolutionCallback: localeListResolutionCallback,
             localeResolutionCallback: localeResolutionCallback,

--- a/lib/src/navigation/root/root_widget.dart
+++ b/lib/src/navigation/root/root_widget.dart
@@ -281,7 +281,7 @@ extension Trans on String {
         Get.translations[Get.locale.languageCode].containsKey(this)) {
       return Get.translations[Get.locale.languageCode][this];
       // If there is no corresponding language or corresponding key, return the key.
-    } else if (Get.translations.containsKey(
+    } else if (Get.fallbackLocale != null && Get.translations.containsKey(
             "${Get.fallbackLocale.languageCode}_${Get.fallbackLocale.countryCode}") &&
         Get.translations[
                 "${Get.fallbackLocale.languageCode}_${Get.fallbackLocale.countryCode}"]

--- a/lib/src/navigation/root/root_widget.dart
+++ b/lib/src/navigation/root/root_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+iimport 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:get/src/instance/get_instance.dart';
@@ -30,6 +30,7 @@ class GetMaterialApp extends StatelessWidget {
     this.darkTheme,
     this.themeMode = ThemeMode.system,
     this.locale,
+    this.fallbackLocale,
     this.localizationsDelegates,
     this.localeListResolutionCallback,
     this.localeResolutionCallback,
@@ -83,6 +84,7 @@ class GetMaterialApp extends StatelessWidget {
   final Map<String, Map<String, String>> translationsKeys;
   final Translations translations;
   final Locale locale;
+  final Locale fallbackLocale;
   final Iterable<LocalizationsDelegate<dynamic>> localizationsDelegates;
   final LocaleListResolutionCallback localeListResolutionCallback;
   final LocaleResolutionCallback localeResolutionCallback;
@@ -186,6 +188,10 @@ class GetMaterialApp extends StatelessWidget {
             Get.locale = locale;
           }
 
+          if (fallbackLocale != null) {
+            Get.fallbackLocale = fallbackLocale;
+          }
+
           if (translations != null) {
             Get.translations = translations.keys;
           } else if (translationsKeys != null) {
@@ -234,6 +240,7 @@ class GetMaterialApp extends StatelessWidget {
             darkTheme: darkTheme,
             themeMode: _.themeMode ?? themeMode ?? ThemeMode.system,
             locale: Get.locale ?? locale,
+            fallbackLocale: Get.fallbackLocale ?? fallbackLocale,
             localizationsDelegates: localizationsDelegates,
             localeListResolutionCallback: localeListResolutionCallback,
             localeResolutionCallback: localeResolutionCallback,
@@ -275,6 +282,16 @@ extension Trans on String {
         Get.translations[Get.locale.languageCode].containsKey(this)) {
       return Get.translations[Get.locale.languageCode][this];
       // If there is no corresponding language or corresponding key, return the key.
+    } else if (Get.translations.containsKey(
+            "${Get.fallbackLocale.languageCode}_${Get.fallbackLocale.countryCode}") &&
+        Get.translations[
+                "${Get.fallbackLocale.languageCode}_${Get.fallbackLocale.countryCode}"]
+            .containsKey(this)) {
+      return Get.translations[
+              "${Get.fallbackLocale.languageCode}_${Get.fallbackLocale.countryCode}"]
+          [this];
+
+      // Checks if there is a callback language in the absence of the specific country, and if it contains that key.
     } else {
       return this;
     }


### PR DESCRIPTION
Hi, what do you think about this as a solution to issue at [https://github.com/jonataslaw/getx/issues/430](url)
Doing this will allow a specific fallbackLocale. I cant do any tests but tested with the something key translation and it showed "still something" when it failed to find any in nl,BE or nl.

```
 locale: Locale('nl', 'BE'),
 fallbackLocale: Locale('en', 'US'),
 translationsKeys: {
        'nl_BE': {'title': 'Hallo van GetX'},
        'en_US': {'title': 'Hello from GetX', "something": "still something"}
      },
```