### PR TITLE
Abstraction of logging

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,6 +10,8 @@ void main() {
     GetMaterialApp(
       debugShowCheckedModeBanner: false,
       initialRoute: '/',
+      enableLog: true,
+      // logWriterCallback: localLogWriter,
       getPages: [
         GetPage(name: '/', page: () => HomePage(), binding: HomeBinding()),
         GetPage(name: '/country', page: () => CountryPage()),
@@ -17,4 +19,9 @@ void main() {
       ],
     ),
   );
+}
+
+// Sample of abstract logging function
+void localLogWriter(String text, {bool isError = false}) {
+  print('** ' + text + ' [' + isError.toString() + ']');
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -24,10 +24,10 @@ dependencies:
   flutter:
     sdk: flutter
 
-
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  get: ^3.2.2 
+  get:
+    path: ../
   dio: ^3.0.9
 
 dev_dependencies:
@@ -39,23 +39,18 @@ dev_dependencies:
 
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
-
   # To add assets to your application, add an assets section, like this:
   # assets:
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
-
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware.
-
   # For details regarding adding assets from package dependencies, see
   # https://flutter.dev/assets-and-images/#from-packages
-
   # To add custom fonts to your application, add a fonts section here,
   # in this "flutter" section. Each entry in this list should have a
   # "family" key with the font family name, and a "fonts" key with a

--- a/lib/src/core/log.dart
+++ b/lib/src/core/log.dart
@@ -1,0 +1,7 @@
+import 'package:get/instance_manager.dart';
+
+typedef LogWriterCallback = void Function(String text, {bool isError});
+
+void defaultLogWriterCallback(String value, {bool isError = false}) {
+  if (isError || GetConfig.isLogEnable) print(value);
+}

--- a/lib/src/instance/get_instance.dart
+++ b/lib/src/instance/get_instance.dart
@@ -1,9 +1,11 @@
+import 'package:get/src/core/log.dart';
 import 'package:get/src/navigation/root/smart_management.dart';
 import 'package:get/src/state_manager/rx/rx_interface.dart';
 
 class GetConfig {
   static SmartManagement smartManagement = SmartManagement.full;
   static bool isLogEnable = true;
+  static LogWriterCallback log;
   static String currentRoute;
 }
 
@@ -124,7 +126,7 @@ class GetInstance {
 
     if (i is DisposableInterface) {
       i.onStart();
-      if (GetConfig.isLogEnable) print('[GETX] $key has been initialized');
+      GetConfig.log('[GETX] $key has been initialized');
     }
   }
 
@@ -169,8 +171,7 @@ class GetInstance {
       if (!_factory.containsKey(key))
         throw " $S not found. You need call put<$S>($S()) before";
 
-      if (GetConfig.isLogEnable)
-        print('[GETX] $S instance was created at that time');
+      GetConfig.log('[GETX] $S instance was created at that time');
       S _value = put<S>(_factory[key].builder() as S);
 
       initDependencies<S>(name: tag);
@@ -205,14 +206,15 @@ class GetInstance {
     }
 
     if (!_singl.containsKey(newKey)) {
-      print('Instance $newKey not found');
+      GetConfig.log('Instance $newKey not found', isError: true);
       return false;
     }
 
     FcBuilder builder = _singl[newKey] as FcBuilder;
     if (builder.permanent && !force) {
-      print(
-          '[GETX] [$newKey] has been marked as permanent, SmartManagement is not authorized to delete it.');
+      GetConfig.log(
+          '[GETX] [$newKey] has been marked as permanent, SmartManagement is not authorized to delete it.',
+          isError: true);
       return false;
     }
     final i = builder.dependency;
@@ -222,14 +224,14 @@ class GetInstance {
     }
     if (i is DisposableInterface) {
       await i.onClose();
-      if (GetConfig.isLogEnable) print('[GETX] onClose of $newKey called');
+      GetConfig.log('[GETX] onClose of $newKey called');
     }
 
     _singl.removeWhere((oldKey, value) => (oldKey == newKey));
     if (_singl.containsKey(newKey)) {
-      print('[GETX] error on remove object $newKey');
+      GetConfig.log('[GETX] error on remove object $newKey', isError: true);
     } else {
-      if (GetConfig.isLogEnable) print('[GETX] $newKey deleted from memory');
+      GetConfig.log('[GETX] $newKey deleted from memory');
     }
     // _routesKey?.remove(key);
     return true;

--- a/lib/src/instance/get_instance.dart
+++ b/lib/src/instance/get_instance.dart
@@ -5,7 +5,7 @@ import 'package:get/src/state_manager/rx/rx_interface.dart';
 class GetConfig {
   static SmartManagement smartManagement = SmartManagement.full;
   static bool isLogEnable = true;
-  static LogWriterCallback log;
+  static LogWriterCallback log = defaultLogWriterCallback;
   static String currentRoute;
 }
 

--- a/lib/src/navigation/extension_navigation.dart
+++ b/lib/src/navigation/extension_navigation.dart
@@ -773,7 +773,9 @@ extension GetNavigation on GetInterface {
     if (enableLog != null) {
       GetConfig.isLogEnable = enableLog;
     }
-    GetConfig.log = logWriterCallback;
+    if (logWriterCallback != null) {
+      GetConfig.log = logWriterCallback;
+    }
     if (defaultPopGesture != null) {
       this.defaultPopGesture = defaultPopGesture;
     }

--- a/lib/src/navigation/extension_navigation.dart
+++ b/lib/src/navigation/extension_navigation.dart
@@ -3,6 +3,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:get/src/core/get_interface.dart';
 import 'package:get/instance_manager.dart';
 import 'package:get/route_manager.dart';
+import 'package:get/src/core/log.dart';
 import 'root/parse_route.dart';
 import 'routes/bindings_interface.dart';
 
@@ -763,6 +764,7 @@ extension GetNavigation on GetInterface {
   /// change default config of Get
   void config(
       {bool enableLog,
+      LogWriterCallback logWriterCallback,
       bool defaultPopGesture,
       bool defaultOpaqueRoute,
       Duration defaultDurationTransition,
@@ -771,6 +773,7 @@ extension GetNavigation on GetInterface {
     if (enableLog != null) {
       GetConfig.isLogEnable = enableLog;
     }
+    GetConfig.log = logWriterCallback;
     if (defaultPopGesture != null) {
       this.defaultPopGesture = defaultPopGesture;
     }

--- a/lib/src/navigation/root/root_widget.dart
+++ b/lib/src/navigation/root/root_widget.dart
@@ -204,7 +204,7 @@ class GetMaterialApp extends StatelessWidget {
 
           Get.config(
             enableLog: enableLog ?? GetConfig.isLogEnable,
-            logWriterCallback: logWriterCallback ?? defaultLogWriterCallback,
+            logWriterCallback: logWriterCallback,
             defaultTransition: defaultTransition ?? Get.defaultTransition,
             defaultOpaqueRoute: opaqueRoute ?? Get.isOpaqueRouteDefault,
             defaultPopGesture: popGesture ?? Get.isPopGestureEnable,

--- a/lib/src/navigation/root/root_widget.dart
+++ b/lib/src/navigation/root/root_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:get/src/core/log.dart';
 import 'package:get/src/instance/get_instance.dart';
 import 'package:get/src/navigation/routes/get_route.dart';
 import 'root_controller.dart';
@@ -51,6 +52,7 @@ class GetMaterialApp extends StatelessWidget {
     this.getPages,
     this.opaqueRoute,
     this.enableLog,
+    this.logWriterCallback,
     this.popGesture,
     this.transitionDuration,
     this.defaultGlobalState,
@@ -103,6 +105,7 @@ class GetMaterialApp extends StatelessWidget {
   final VoidCallback onInit;
   final VoidCallback onDispose;
   final bool enableLog;
+  final LogWriterCallback logWriterCallback;
   final bool popGesture;
   final SmartManagement smartManagement;
   final Bindings initialBinding;
@@ -201,6 +204,7 @@ class GetMaterialApp extends StatelessWidget {
 
           Get.config(
             enableLog: enableLog ?? GetConfig.isLogEnable,
+            logWriterCallback: logWriterCallback ?? defaultLogWriterCallback,
             defaultTransition: defaultTransition ?? Get.defaultTransition,
             defaultOpaqueRoute: opaqueRoute ?? Get.isOpaqueRouteDefault,
             defaultPopGesture: popGesture ?? Get.isPopGestureEnable,

--- a/lib/src/navigation/routes/observers/route_observer.dart
+++ b/lib/src/navigation/routes/observers/route_observer.dart
@@ -49,17 +49,13 @@ class GetObserver extends NavigatorObserver {
   @override
   void didPush(Route<dynamic> route, Route<dynamic> previousRoute) {
     if ('${route?.settings?.name}' == 'snackbar') {
-      if (GetConfig.isLogEnable)
-        print("[GETX] OPEN SNACKBAR ${route?.settings?.name}");
+      GetConfig.log("[GETX] OPEN SNACKBAR ${route?.settings?.name}");
     } else if ('${route?.settings?.name}' == 'bottomsheet') {
-      if (GetConfig.isLogEnable)
-        print("[GETX] OPEN BOTTOMSHEET ${route?.settings?.name}");
+      GetConfig.log("[GETX] OPEN BOTTOMSHEET ${route?.settings?.name}");
     } else if ('${route?.settings?.name}' == 'dialog') {
-      if (GetConfig.isLogEnable)
-        print("[GETX] OPEN DIALOG ${route?.settings?.name}");
+      GetConfig.log("[GETX] OPEN DIALOG ${route?.settings?.name}");
     } else {
-      if (GetConfig.isLogEnable)
-        print("[GETX] GOING TO ROUTE ${route?.settings?.name}");
+      GetConfig.log("[GETX] GOING TO ROUTE ${route?.settings?.name}");
     }
 
     _routeSend.update((value) {
@@ -81,17 +77,13 @@ class GetObserver extends NavigatorObserver {
     super.didPop(route, previousRoute);
 
     if ('${route?.settings?.name}' == 'snackbar') {
-      if (GetConfig.isLogEnable)
-        print("[GETX] CLOSE SNACKBAR ${route?.settings?.name}");
+      GetConfig.log("[GETX] CLOSE SNACKBAR ${route?.settings?.name}");
     } else if ('${route?.settings?.name}' == 'bottomsheet') {
-      if (GetConfig.isLogEnable)
-        print("[GETX] CLOSE BOTTOMSHEET ${route?.settings?.name}");
+      GetConfig.log("[GETX] CLOSE BOTTOMSHEET ${route?.settings?.name}");
     } else if ('${route?.settings?.name}' == 'dialog') {
-      if (GetConfig.isLogEnable)
-        print("[GETX] CLOSE DIALOG ${route?.settings?.name}");
+      GetConfig.log("[GETX] CLOSE DIALOG ${route?.settings?.name}");
     } else {
-      if (GetConfig.isLogEnable)
-        print("[GETX] BACK ROUTE ${route?.settings?.name}");
+      GetConfig.log("[GETX] BACK ROUTE ${route?.settings?.name}");
     }
 
     _routeSend.update((value) {
@@ -112,10 +104,8 @@ class GetObserver extends NavigatorObserver {
   @override
   void didReplace({Route newRoute, Route oldRoute}) {
     super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
-    if (GetConfig.isLogEnable)
-      print("[GETX] REPLACE ROUTE ${oldRoute?.settings?.name}");
-    if (GetConfig.isLogEnable)
-      print("[GETX] NEW ROUTE ${newRoute?.settings?.name}");
+    GetConfig.log("[GETX] REPLACE ROUTE ${oldRoute?.settings?.name}");
+    GetConfig.log("[GETX] NEW ROUTE ${newRoute?.settings?.name}");
 
     _routeSend.update((value) {
       if (newRoute is PageRoute) value.current = '${newRoute?.settings?.name}';
@@ -134,8 +124,7 @@ class GetObserver extends NavigatorObserver {
   @override
   void didRemove(Route route, Route previousRoute) {
     super.didRemove(route, previousRoute);
-    if (GetConfig.isLogEnable)
-      print("[GETX] REMOVING ROUTE ${route?.settings?.name}");
+    GetConfig.log("[GETX] REMOVING ROUTE ${route?.settings?.name}");
 
     _routeSend.update((value) {
       value.route = previousRoute;

--- a/lib/src/state_manager/rx/rx_event.dart
+++ b/lib/src/state_manager/rx/rx_event.dart
@@ -100,7 +100,7 @@ class Worker {
   final String type;
 
   void _message() {
-    if (GetConfig.isLogEnable) print('[Getx] Worker $type disposed');
+    GetConfig.log('[Getx] Worker $type disposed');
   }
 
   void dispose() {


### PR DESCRIPTION
Hi

There is some logging in the package currently, all simple `print` statements.

However, when integrating the getX package with logging libraries it would be nice to be able to capture these log lines in once place.

Therefore I created an abstraction of the log print statements, into a Callback. Everywhere where you used the `print` statement and the check if the log is enabled, I replaced it with a single statement like `GetConfig.log('[GETX] $key has been initialized');`

A few locations had a `print` statement for errors too (no check if logging is enabled). This is replaced with the same but with the optional parameter `GetConfig.log('Instance $newKey not found', isError: true);`.

By doing this, it is now possible to replace the logging by a log provider the dev chooses.

I changed (and tested) it in the sample application.

```
GetMaterialApp(
      debugShowCheckedModeBanner: false,
      initialRoute: '/',
      enableLog: true,
      logWriterCallback: localLogWriter,
      getPages: [
        GetPage(name: '/', page: () => HomePage(), binding: HomeBinding()),
        GetPage(name: '/country', page: () => CountryPage()),
        GetPage(name: '/details', page: () => DetailsPage()),
      ],
    ),
```

and define your log writer:

```
void localLogWriter(String text, {bool isError = false}) {
  // use your own log library here -- for demo, just the same print
  print('** ' + text + ' [' + isError.toString() + ']');
}
```

Of course this is optional. You can remove the `logWriterCallback` assignment to use the default implementation.

I hope you like the change. This would be really helpful for myself to route the logs to my own log provider.

