### PR TITLE
subtle Rx improvements and docs.

### DIFF
--- a/lib/src/navigation/extension_navigation.dart
+++ b/lib/src/navigation/extension_navigation.dart
@@ -519,6 +519,7 @@ extension GetNavigation on GetInterface {
   /// Custom UI Dialog.
   Future<T> defaultDialog<T>({
     String title = "Alert",
+    TextStyle titleStyle,
     Widget content,
     VoidCallback onConfirm,
     VoidCallback onCancel,
@@ -534,7 +535,9 @@ extension GetNavigation on GetInterface {
     Color backgroundColor,
     Color buttonColor,
     String middleText = "Dialog made in 3 lines of code",
+    TextStyle middleTextStyle,
     double radius = 20.0,
+ //   ThemeData themeData,
     List<Widget> actions,
   }) {
     var leanCancel = onCancel != null || textCancel != null;
@@ -583,34 +586,39 @@ extension GetNavigation on GetInterface {
             }));
       }
     }
-    return dialog(AlertDialog(
-      titlePadding: EdgeInsets.all(8),
-      contentPadding: EdgeInsets.all(8),
-      backgroundColor: backgroundColor ?? theme.dialogBackgroundColor,
-      shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(Radius.circular(radius))),
-      title: Text(title, textAlign: TextAlign.center),
-      content: Column(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          content ?? Text(middleText ?? "", textAlign: TextAlign.center),
-          SizedBox(height: 16),
-          ButtonTheme(
-            minWidth: 78.0,
-            height: 34.0,
-            child: Wrap(
-              alignment: WrapAlignment.center,
-              spacing: 8,
-              runSpacing: 8,
-              children: actions,
-            ),
-          )
-        ],
+
+    return dialog(
+      AlertDialog(
+        titlePadding: EdgeInsets.all(8),
+        contentPadding: EdgeInsets.all(8),
+        backgroundColor: backgroundColor ?? theme.dialogBackgroundColor,
+        shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(radius))),
+        title: Text(title, textAlign: TextAlign.center, style: titleStyle),
+        content: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            content ??
+                Text(middleText ?? "",
+                    textAlign: TextAlign.center, style: middleTextStyle),
+            SizedBox(height: 16),
+            ButtonTheme(
+              minWidth: 78.0,
+              height: 34.0,
+              child: Wrap(
+                alignment: WrapAlignment.center,
+                spacing: 8,
+                runSpacing: 8,
+                children: actions,
+              ),
+            )
+          ],
+        ),
+        // actions: actions, // ?? <Widget>[cancelButton, confirmButton],
+        buttonPadding: EdgeInsets.zero,
       ),
-      // actions: actions, // ?? <Widget>[cancelButton, confirmButton],
-      buttonPadding: EdgeInsets.zero,
-    ));
+    );
   }
 
   Future<T> bottomSheet<T>(

--- a/lib/src/navigation/extension_navigation.dart
+++ b/lib/src/navigation/extension_navigation.dart
@@ -519,7 +519,6 @@ extension GetNavigation on GetInterface {
   /// Custom UI Dialog.
   Future<T> defaultDialog<T>({
     String title = "Alert",
-    TextStyle titleStyle,
     Widget content,
     VoidCallback onConfirm,
     VoidCallback onCancel,
@@ -535,9 +534,7 @@ extension GetNavigation on GetInterface {
     Color backgroundColor,
     Color buttonColor,
     String middleText = "Dialog made in 3 lines of code",
-    TextStyle middleTextStyle,
     double radius = 20.0,
- //   ThemeData themeData,
     List<Widget> actions,
   }) {
     var leanCancel = onCancel != null || textCancel != null;
@@ -586,39 +583,34 @@ extension GetNavigation on GetInterface {
             }));
       }
     }
-
-    return dialog(
-      AlertDialog(
-        titlePadding: EdgeInsets.all(8),
-        contentPadding: EdgeInsets.all(8),
-        backgroundColor: backgroundColor ?? theme.dialogBackgroundColor,
-        shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(radius))),
-        title: Text(title, textAlign: TextAlign.center, style: titleStyle),
-        content: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            content ??
-                Text(middleText ?? "",
-                    textAlign: TextAlign.center, style: middleTextStyle),
-            SizedBox(height: 16),
-            ButtonTheme(
-              minWidth: 78.0,
-              height: 34.0,
-              child: Wrap(
-                alignment: WrapAlignment.center,
-                spacing: 8,
-                runSpacing: 8,
-                children: actions,
-              ),
-            )
-          ],
-        ),
-        // actions: actions, // ?? <Widget>[cancelButton, confirmButton],
-        buttonPadding: EdgeInsets.zero,
+    return dialog(AlertDialog(
+      titlePadding: EdgeInsets.all(8),
+      contentPadding: EdgeInsets.all(8),
+      backgroundColor: backgroundColor ?? theme.dialogBackgroundColor,
+      shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(radius))),
+      title: Text(title, textAlign: TextAlign.center),
+      content: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          content ?? Text(middleText ?? "", textAlign: TextAlign.center),
+          SizedBox(height: 16),
+          ButtonTheme(
+            minWidth: 78.0,
+            height: 34.0,
+            child: Wrap(
+              alignment: WrapAlignment.center,
+              spacing: 8,
+              runSpacing: 8,
+              children: actions,
+            ),
+          )
+        ],
       ),
-    );
+      // actions: actions, // ?? <Widget>[cancelButton, confirmButton],
+      buttonPadding: EdgeInsets.zero,
+    ));
   }
 
   Future<T> bottomSheet<T>(

--- a/lib/src/state_manager/rx/rx_core/rx_impl.dart
+++ b/lib/src/state_manager/rx/rx_core/rx_impl.dart
@@ -163,7 +163,7 @@ class _RxImpl<T> implements RxInterface<T> {
 
 
   /// Updates the [value] and adds it to the stream, updating the observer
-  /// Widget, only it's different from the previous value.
+  /// Widget, only if it's different from the previous value.
   set value(T val) {
     if (_value == val && !firstRebuild) return;
     firstRebuild = false;


### PR DESCRIPTION
- small comment fix (https://github.com/jonataslaw/getx/pull/560#commitcomment-42045326)
- added `RxBool.toggle()`as an easy shortcut for switching true/false values.
- added `_RxImp.nil()` to easily set the value to `null` (`nil` comes from LISP :P) seems to be a useful sometimes, for instance if using `RxString` in `TextField.decoration.errorText` is the only way to avoid the "error state".
- adds missing docs to Rx classes.