### PR TITLE
Get.delete update and some missing docs

### DIFF
--- a/lib/src/instance/extension_instance.dart
+++ b/lib/src/instance/extension_instance.dart
@@ -92,12 +92,16 @@ extension Inst on GetInterface {
   /// controllers ([DisposableInterface]).
   ///
   /// - [tag] Optional "tag" used to register the Instance
-  Future<bool> delete<S>({String tag}) async =>
-      GetInstance().delete<S>(tag: tag);
+  /// - [force] Will delete an Instance even if marked as [permanent].
+  Future<bool> delete<S>({String tag, bool force = false}) async =>
+      GetInstance().delete<S>(tag: tag, force: force);
 
-  /// Check if a Class Instance<[S]> (or [tag]) is registered in memory.
+  /// Checks if a Class Instance<[S]> (or [tag]) is registered in memory.
   /// - [tag] optional, if you use a [tag] to register the Instance.
   bool isRegistered<S>({String tag}) => GetInstance().isRegistered<S>(tag: tag);
 
+  /// Checks if an Instance<[S]> (or [tag]) returned from a factory builder
+  /// [Get.lazyPut()], is registered in memory.
+  /// - [tag] optional, if you use a [tag] to register the Instance.
   bool isPrepared<S>({String tag}) => GetInstance().isPrepared<S>(tag: tag);
 }

--- a/lib/src/instance/get_instance.dart
+++ b/lib/src/instance/get_instance.dart
@@ -340,12 +340,12 @@ class GetInstance {
   }
 
   /// Check if a Class Instance<[S]> (or [tag]) is registered in memory.
-  /// - [tag] optional, if you use a [tag] to register the Instance.
+  /// - [tag] is optional, if you used a [tag] to register the Instance.
   bool isRegistered<S>({String tag}) => _singl.containsKey(_getKey(S, tag));
 
-  /// Checks if a lazy factory callback that returns an Instance<[S]>
-  /// is registered.
-  /// - [tag] optional, if you use a [tag] to register the Instance.
+  /// Checks if a lazy factory callback ([Get.lazyPut()] that returns an
+  /// Instance<[S]> is registered in memory.
+  /// - [tag] is optional, if you used a [tag] to register the lazy Instance.
   bool isPrepared<S>({String tag}) => _factory.containsKey(_getKey(S, tag));
 }
 


### PR DESCRIPTION
- Added `Get.delete(force:false)` which was missing to manually remove permanent instances with Get.put().
- added missing doc comment to `Get.isPrepared()`