### PR TITLE
[Feature] Ability to use tags with GetX widgets

### DIFF
--- a/lib/src/state_manager/rx/rx_widgets/rx_getx_widget.dart
+++ b/lib/src/state_manager/rx/rx_widgets/rx_getx_widget.dart
@@ -21,7 +21,7 @@ class GetX<T extends DisposableInterface> extends StatefulWidget {
   final String tag;
 
   const GetX({
-    this.tag = null,
+    this.tag,
     this.builder,
     this.global = true,
     this.autoRemove = true,

--- a/lib/src/state_manager/rx/rx_widgets/rx_getx_widget.dart
+++ b/lib/src/state_manager/rx/rx_widgets/rx_getx_widget.dart
@@ -47,22 +47,22 @@ class GetImplXState<T extends DisposableInterface> extends State<GetX<T>> {
   @override
   void initState() {
     _observer = Rx();
-    var isPrepared = GetInstance().isPrepared<T>(tag: tag);
-    var isRegistered = GetInstance().isRegistered<T>(tag: tag);
+    var isPrepared = GetInstance().isPrepared<T>(tag: widget.tag);
+    var isRegistered = GetInstance().isRegistered<T>(tag: widget.tag);
 
     if (widget.global) {
       if (isPrepared) {
         if (GetConfig.smartManagement != SmartManagement.keepFactory) {
           isCreator = true;
         }
-        controller = GetInstance().find<T>(tag: tag);
+        controller = GetInstance().find<T>(tag: widget.tag);
       } else if (isRegistered) {
-        controller = GetInstance().find<T>(tag: tag);
+        controller = GetInstance().find<T>(tag: widget.tag);
         isCreator = false;
       } else {
         controller = widget.init;
         isCreator = true;
-        GetInstance().put<T>(controller, tag: tag);
+        GetInstance().put<T>(controller, tag: widget.tag);
       }
     } else {
       controller = widget.init;
@@ -96,8 +96,8 @@ class GetImplXState<T extends DisposableInterface> extends State<GetX<T>> {
   void dispose() {
     if (widget.dispose != null) widget.dispose(this);
     if (isCreator || widget.assignId) {
-      if (widget.autoRemove && GetInstance().isRegistered<T>(tag: tag)) {
-        GetInstance().delete<T>(tag: tag);
+      if (widget.autoRemove && GetInstance().isRegistered<T>(tag: widget.tag)) {
+        GetInstance().delete<T>(tag: widget.tag);
       }
     }
     subs.cancel();

--- a/lib/src/state_manager/rx/rx_widgets/rx_getx_widget.dart
+++ b/lib/src/state_manager/rx/rx_widgets/rx_getx_widget.dart
@@ -18,8 +18,10 @@ class GetX<T extends DisposableInterface> extends StatefulWidget {
   final void Function(State state) initState, dispose, didChangeDependencies;
   final void Function(GetX oldWidget, State state) didUpdateWidget;
   final T init;
+  final String tag;
 
   const GetX({
+    this.tag = null,
     this.builder,
     this.global = true,
     this.autoRemove = true,
@@ -45,22 +47,22 @@ class GetImplXState<T extends DisposableInterface> extends State<GetX<T>> {
   @override
   void initState() {
     _observer = Rx();
-    var isPrepared = GetInstance().isPrepared<T>();
-    var isRegistered = GetInstance().isRegistered<T>();
+    var isPrepared = GetInstance().isPrepared<T>(tag: tag);
+    var isRegistered = GetInstance().isRegistered<T>(tag: tag);
 
     if (widget.global) {
       if (isPrepared) {
         if (GetConfig.smartManagement != SmartManagement.keepFactory) {
           isCreator = true;
         }
-        controller = GetInstance().find<T>();
+        controller = GetInstance().find<T>(tag: tag);
       } else if (isRegistered) {
-        controller = GetInstance().find<T>();
+        controller = GetInstance().find<T>(tag: tag);
         isCreator = false;
       } else {
         controller = widget.init;
         isCreator = true;
-        GetInstance().put<T>(controller);
+        GetInstance().put<T>(controller, tag: tag);
       }
     } else {
       controller = widget.init;
@@ -94,8 +96,8 @@ class GetImplXState<T extends DisposableInterface> extends State<GetX<T>> {
   void dispose() {
     if (widget.dispose != null) widget.dispose(this);
     if (isCreator || widget.assignId) {
-      if (widget.autoRemove && GetInstance().isRegistered<T>()) {
-        GetInstance().delete<T>();
+      if (widget.autoRemove && GetInstance().isRegistered<T>(tag: tag)) {
+        GetInstance().delete<T>(tag: tag);
       }
     }
     subs.cancel();

--- a/lib/src/state_manager/simple/get_view.dart
+++ b/lib/src/state_manager/simple/get_view.dart
@@ -40,7 +40,7 @@ abstract class GetWidget<T> extends StatelessWidget {
   final String tag = null;
 
   T get controller {
-    if (_value.isEmpty) _value.add(GetInstance().find<T>());
+    if (_value.isEmpty) _value.add(GetInstance().find<T>(tag: tag));
     return _value.first;
   }
 


### PR DESCRIPTION
A simple update to facilitate the use of tagged controllers in a `GetX` widget.

### Before

```dart
class SimplePage extends StatelessWidget {
  final Controller controller = Get.find(tag: "my-tag");

  @override
  Widget build() {
    return GetX(
      // _ is null :-(
      builder: (_) => Center(child: Text(controller.text)),
    );
  }
}

class ComplexPage extends StatelessWidget {
  final Controller controller1 = Get.find(tag: "my-tag-1");
  final Controller controller2 = Get.find(tag: "my-tag-2");

  @override
  Widget build() {
    return Column(
      children: <Widget>[
        Expanded(
          child: GetX(
            // _ is null :-(
            builder: (_) => Center(child: Text(controller1.text)),
          ),
        ),
        Expanded(
          child: GetX(
            // _ is null :-(
            builder: (_) => Center(child: Text(controller2.text)),
          ),
        ),
      ],
    );
  }
}
```

### After

```dart
class SimplePage extends StatelessWidget {
  @override
  Widget build() {
    return GetX<Controller>(
      tag: "my-tag",
      builder: (controller) => Center(child: Text(controller.text)),
    );
  }
}

class ComplexPage extends StatelessWidget {
  @override
  Widget build() {
    return Column(
      children: <Widget>[
        Expanded(
          child: GetX<Controller>(
            tag: "my-tag-1",
            builder: (controller) => Center(child: Text(controller.text)),
          ),
        ),
        Expanded(
          child: GetX<Controller>(
            tag: "my-tag-2",
            builder: (controller) => Center(child: Text(controller.text)),
          ),
        ),
      ],
    );
  }
}
```

### Side notes

I've also fixed a little issue in `GetWidget`, the introduced `tag` feature was not used when the controller is created using `Get.find()`