### PR TITLE
Resolvendo bug ao executar flutter analyze

### DIFF
--- a/lib/src/navigation/extension_navigation.dart
+++ b/lib/src/navigation/extension_navigation.dart
@@ -1056,4 +1056,4 @@ Since version 2.8 it is possible to access the properties
 /// It replaces the Flutter Navigator, but needs no context.
 /// You can to use navigator.push(YourRoute()) rather
 /// Navigator.push(context, YourRoute());
-NavigatorState get navigator => Get.key.currentState;
+NavigatorState get navigator => GetNavigation(Get).key.currentState;


### PR DESCRIPTION
Na linha 1059 do arquivo lib\src\navigation\extension_navigation.dart é gerado um erro no flutter analyze e também no vscode:

`NavigatorState get navigator => Get.key.currentState;`

O erro se refere a uma possível ambiguidade do getter key da extensão GetNavigation . Dei uma olhada nessa documentação do Dart (https://dart.dev/tools/diagnostic-messages#ambiguous_extension_member_access) e vi uma possível solução usando a extensão de forma explícita. O código com uma pequena mudança ficaria assim:

`NavigatorState get navigator => GetNavigation(Get).key.currentState;`

Depois disso o flutter analyze passou e não apontou mais erro no vscode