### PR TITLE
Fix for switch types usages in GetUtils

### DIFF
--- a/lib/src/utils/regex/get_utils.dart
+++ b/lib/src/utils/regex/get_utils.dart
@@ -70,14 +70,13 @@ class GetUtils {
       return true;
     }
 
-    /// FIXME: null checking here is.. pointless (? see isNull above)
     if(value is String) {
-      return value.toString() == 'null' || value.toString().trim().isEmpty;
+      return value.toString().trim().isEmpty;
     }
 
     // Pretty sure that isNullOrBlank should't be validating
     // iterables... but I'm going to keep this for compatibility.
-    return _hasIsEmpty(value) ? value.isEmpty as bool : true;
+    return _hasIsEmpty(value) ? value.isEmpty as bool : false;
   }
 
   /// Checks if string is int or double.

--- a/lib/src/utils/regex/get_utils.dart
+++ b/lib/src/utils/regex/get_utils.dart
@@ -1,8 +1,60 @@
 import '../../../get.dart';
 
+/// Returns whether a dynamic value PROBABLY
+/// has the isEmpty getter/method by checking
+/// standard dart types that contains it.
+///
+/// This is here to for the 'DRY'
+bool _hasIsEmpty(dynamic value) {
+  return value is Iterable || value is String || value is Map;
+}
+
+/// Returns whether a dynamic value PROBABLY
+/// has the length getter/method by checking
+/// standard dart types that contains it.
+///
+/// This is here to for the 'DRY'
+bool _hasLength(dynamic value) {
+  return value is Iterable || value is String || value is Map;
+}
+
+/// Obtains a length of a dynamic value
+/// by previously validating it's type
+///
+/// Note: if [value] is double/int
+/// it will be taking the .toString
+/// length of the given value.
+///
+/// Note 2: **this may return null!**
+///
+/// Note 3: null [value] returns null.
+int _obtainDynamicLength(dynamic value) {
+  if (value == null) {
+    // ignore: avoid_returning_null
+    return null;
+  }
+
+  if (_hasLength(value)) {
+    return value.length as int;
+  }
+
+  if (value is int) {
+    return value.toString().length;
+  }
+
+  if (value is double) {
+    return value.toString().replaceAll('.', '').length;
+  }
+
+  // ignore: avoid_returning_null
+  return null;
+}
+
 class GetUtils {
+  GetUtils._();
+
   /// Checks if data is null.
-  static bool isNull(dynamic s) => s == null;
+  static bool isNull(dynamic value) => value == null;
 
   /// In dart2js (in flutter v1.17) a var by default is undefined.
   /// *Use this only if you are in version <- 1.17*.
@@ -13,20 +65,28 @@ class GetUtils {
   static dynamic nil(dynamic s) => s == null ? null : s;
 
   /// Checks if data is null or blank (empty or only contains whitespace).
-  static bool isNullOrBlank(dynamic s) {
-    if (isNull(s)) return true;
-
-    if (s is String || s is List || s is Map || s is Set || s is Iterable) {
-      return s.isEmpty as bool;
-    } else {
-      return s.toString() == 'null' || s.toString().trim().isEmpty;
+  static bool isNullOrBlank(dynamic value) {
+    if (isNull(value)) {
+      return true;
     }
+
+    /// FIXME: null checking here is.. pointless (? see isNull above)
+    if(value is String) {
+      return value.toString() == 'null' || value.toString().trim().isEmpty;
+    }
+
+    // Pretty sure that isNullOrBlank should't be validating
+    // iterables... but I'm going to keep this for compatibility.
+    return _hasIsEmpty(value) ? value.isEmpty as bool : true;
   }
 
   /// Checks if string is int or double.
-  static bool isNum(String s) {
-    if (isNull(s)) return false;
-    return num.tryParse(s) is num ?? false;
+  static bool isNum(String value) {
+    if (isNull(value)) {
+      return false;
+    }
+
+    return num.tryParse(value) is num;
   }
 
   /// Checks if string consist only numeric.
@@ -37,9 +97,12 @@ class GetUtils {
   static bool isAlphabetOnly(String s) => hasMatch(s, r'^[a-zA-Z]+$');
 
   /// Checks if string is boolean.
-  static bool isBool(String s) {
-    if (isNull(s)) return false;
-    return (s == 'true' || s == 'false');
+  static bool isBool(String value) {
+    if (isNull(value)) {
+      return false;
+    }
+
+    return (value == 'true' || value == 'false');
   }
 
   /// Checks if string is an video file.
@@ -80,18 +143,21 @@ class GetUtils {
   /// Checks if string is an powerpoint file.
   static bool isPPT(String filePath) {
     final ext = filePath.toLowerCase();
+
     return ext.endsWith(".ppt") || ext.endsWith(".pptx");
   }
 
   /// Checks if string is an word file.
   static bool isWord(String filePath) {
     final ext = filePath.toLowerCase();
+
     return ext.endsWith(".doc") || ext.endsWith(".docx");
   }
 
   /// Checks if string is an excel file.
   static bool isExcel(String filePath) {
     final ext = filePath.toLowerCase();
+
     return ext.endsWith(".xls") || ext.endsWith(".xlsx");
   }
 
@@ -177,42 +243,50 @@ class GetUtils {
       hasMatch(s, r'^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$');
 
   /// Checks if string is Palindrom.
-  static bool isPalindrom(String s) {
-    final cleanString = s
+  static bool isPalindrom(String string) {
+    final cleanString = string
         .toLowerCase()
         .replaceAll(RegExp(r"\s+"), '')
         .replaceAll(RegExp(r"[^0-9a-zA-Z]+"), "");
-    var isPalindrom = true;
+
     for (var i = 0; i < cleanString.length; i++) {
       if (cleanString[i] != cleanString[cleanString.length - i - 1]) {
-        isPalindrom = false;
+        return false;
       }
     }
-    return isPalindrom;
+
+    return true;
   }
 
   /// Checks if all data have same value.
   /// Example: 111111 -> true, wwwww -> true, [1,1,1,1] -> true
-  static bool isOneAKind(dynamic s) {
-    if ((s is String || s is List) && !isNullOrBlank(s)) {
-      var first = s[0];
-      var isOneAKind = true;
-      var len = s.length as num;
+  static bool isOneAKind(dynamic value) {
+    if ((value is String || value is List) && !isNullOrBlank(value)) {
+      final first = value[0];
+      final len = value.length as num;
+
       for (var i = 0; i < len; i++) {
-        if (s[i] != first) isOneAKind = false;
+        if (value[i] != first) {
+          return false;
+        }
       }
-      return isOneAKind;
+
+      return true;
     }
 
-    if (s is int) {
-      var value = s.toString();
-      var first = value[0];
-      var isOneAKind = true;
-      for (var i = 0; i < value.length; i++) {
-        if (value[i] != first) isOneAKind = false;
+    if (value is int) {
+      final stringValue = value.toString();
+      final first = stringValue[0];
+
+      for (var i = 0; i < stringValue.length; i++) {
+        if (stringValue[i] != first) {
+          return false;
+        }
       }
-      return isOneAKind;
+
+      return true;
     }
+
     return false;
   }
 
@@ -224,124 +298,96 @@ class GetUtils {
   static bool isCurrency(String s) => hasMatch(s,
       r'^(S?\$|\₩|Rp|\¥|\€|\₹|\₽|fr|R\$|R)?[ ]?[-]?([0-9]{1,3}[,.]([0-9]{3}[,.])*[0-9]{3}|[0-9]+)([,.][0-9]{1,2})?( ?(USD?|AUD|NZD|CAD|CHF|GBP|CNY|EUR|JPY|IDR|MXN|NOK|KRW|TRY|INR|RUB|BRL|ZAR|SGD|MYR))?$');
 
-  /// Checks if length of data is LOWER than maxLength.
-  static bool isLengthLowerThan(dynamic s, int maxLength) {
-    if (isNull(s)) return (maxLength <= 0) ? true : false;
-    switch (s.runtimeType as Type) {
-      case String:
-      case List:
-      case Map:
-      case Set:
-      case Iterable:
-        return (s.length as num) < maxLength;
-      case int:
-        return s.toString().length < maxLength;
-      case double:
-        return s.toString().replaceAll('.', '').length < maxLength;
-      default:
-        return false;
-    }
-  }
-
   /// Checks if length of data is GREATER than maxLength.
-  static bool isLengthGreaterThan(dynamic s, int maxLength) {
-    if (isNull(s)) return false;
-    switch (s.runtimeType as Type) {
-      case String:
-      case List:
-      case Map:
-      case Set:
-      case Iterable:
-        return (s.length as num) > maxLength;
-      case int:
-        return s.toString().length > maxLength;
-      case double:
-        return s.toString().replaceAll('.', '').length > maxLength;
-      default:
-        return false;
+  static bool isLengthGreaterThan(dynamic value, int maxLength) {
+    final length = _obtainDynamicLength(value);
+
+    if (length == null) {
+      return false;
     }
+
+    return length > maxLength;
   }
 
   /// Checks if length of data is GREATER OR EQUAL to maxLength.
-  static bool isLengthGreaterOrEqual(dynamic s, int maxLength) {
-    if (isNull(s)) return false;
-    switch (s.runtimeType as Type) {
-      case String:
-      case List:
-      case Map:
-      case Set:
-      case Iterable:
-        return (s.length as num) >= maxLength;
-        break;
-      case int:
-        return s.toString().length >= maxLength;
-        break;
-      case double:
-        return s.toString().replaceAll('.', '').length >= maxLength;
-        break;
-      default:
-        return false;
+  static bool isLengthGreaterOrEqual(dynamic value, int maxLength) {
+    final length = _obtainDynamicLength(value);
+
+    if (length == null) {
+      return false;
     }
+
+    return length >= maxLength;
+  }
+
+  /// Checks if length of data is LOWER than maxLength.
+  ///
+  /// This method is deprecated, use [isLengthLessThan] instead
+  @deprecated
+  static bool isLengthLowerThan(dynamic value, int maxLength) =>
+      isLengthLessThan(value, maxLength);
+
+  /// Checks if length of data is LESS than maxLength.
+  static bool isLengthLessThan(dynamic value, int maxLength) {
+    final length = _obtainDynamicLength(value);
+    if (length == null) {
+      return false;
+    }
+
+    return length < maxLength;
   }
 
   /// Checks if length of data is LOWER OR EQUAL to maxLength.
-  static bool isLengthLowerOrEqual(dynamic s, int maxLength) {
-    if (isNull(s)) return false;
-    switch (s.runtimeType as Type) {
-      case String:
-      case List:
-      case Map:
-      case Set:
-      case Iterable:
-        return (s.length as num) <= maxLength;
-      case int:
-        return s.toString().length <= maxLength;
-      case double:
-        return s.toString().replaceAll('.', '').length <= maxLength;
-      default:
-        return false;
+  ///
+  /// This method is deprecated, use [isLengthLessOrEqual] instead
+  @deprecated
+  static bool isLengthLowerOrEqual(dynamic value, int maxLength) =>
+      isLengthLessOrEqual(value, maxLength);
+
+  /// Checks if length of data is LESS OR EQUAL to maxLength.
+  static bool isLengthLessOrEqual(dynamic value, int maxLength) {
+    final length = _obtainDynamicLength(value);
+
+    if (length == null) {
+      return false;
     }
+
+    return length <= maxLength;
   }
 
   /// Checks if length of data is EQUAL to maxLength.
-  static bool isLengthEqualTo(dynamic s, int maxLength) {
-    if (isNull(s)) return false;
-    switch (s.runtimeType as Type) {
-      case String:
-      case List:
-      case Map:
-      case Set:
-      case Iterable:
-        return s.length == maxLength;
-        break;
-      case int:
-        return s.toString().length == maxLength;
-        break;
-      case double:
-        return s.toString().replaceAll('.', '').length == maxLength;
-        break;
-      default:
-        return false;
+  static bool isLengthEqualTo(dynamic value, int otherLength) {
+    final length = _obtainDynamicLength(value);
+
+    if (length == null) {
+      return false;
     }
+
+    return length == otherLength;
   }
 
   /// Checks if length of data is BETWEEN minLength to maxLength.
-  static bool isLengthBetween(dynamic s, int minLength, int maxLength) {
-    if (isNull(s)) return false;
-    return isLengthGreaterOrEqual(s, minLength) &&
-        isLengthLowerOrEqual(s, maxLength);
+  static bool isLengthBetween(dynamic value, int minLength, int maxLength) {
+    if (isNull(value)) {
+      return false;
+    }
+
+    return isLengthGreaterOrEqual(value, minLength) &&
+        isLengthLowerOrEqual(value, maxLength);
   }
 
   /// Checks if a contains b (Treating or interpreting upper- and lowercase
   /// letters as being the same).
-  static bool isCaseInsensitiveContains(String a, String b) =>
-      a.toLowerCase().contains(b.toLowerCase());
+  static bool isCaseInsensitiveContains(String a, String b) {
+    return a.toLowerCase().contains(b.toLowerCase());
+  }
 
   /// Checks if a contains b or b contains a (Treating or
   /// interpreting upper- and lowercase letters as being the same).
   static bool isCaseInsensitiveContainsAny(String a, String b) {
     final lowA = a.toLowerCase();
     final lowB = b.toLowerCase();
+
     return lowA.contains(lowB) || lowB.contains(lowA);
   }
 
@@ -356,19 +402,25 @@ class GetUtils {
 
   //Check if num is a cnpj
   static bool isCnpj(String cnpj) {
-    if (cnpj == null) return false;
+    if (cnpj == null) {
+      return false;
+    }
 
     // Obter somente os números do CNPJ
-    var numbers = cnpj.replaceAll(RegExp(r'[^0-9]'), '');
+    final numbers = cnpj.replaceAll(RegExp(r'[^0-9]'), '');
 
     // Testar se o CNPJ possui 14 dígitos
-    if (numbers.length != 14) return false;
+    if (numbers.length != 14) {
+      return false;
+    }
 
     // Testar se todos os dígitos do CNPJ são iguais
-    if (RegExp(r'^(\d)\1*$').hasMatch(numbers)) return false;
+    if (RegExp(r'^(\d)\1*$').hasMatch(numbers)) {
+      return false;
+    }
 
     // Dividir dígitos
-    var digits = numbers.split('').map(int.parse).toList();
+    final digits = numbers.split('').map(int.parse).toList();
 
     // Calcular o primeiro dígito verificador
     var calcDv1 = 0;
@@ -377,10 +429,12 @@ class GetUtils {
       calcDv1 += digits[j++] * i;
     }
     calcDv1 %= 11;
-    var dv1 = calcDv1 < 2 ? 0 : 11 - calcDv1;
+    final dv1 = calcDv1 < 2 ? 0 : 11 - calcDv1;
 
     // Testar o primeiro dígito verificado
-    if (digits[12] != dv1) return false;
+    if (digits[12] != dv1) {
+      return false;
+    }
 
     // Calcular o segundo dígito verificador
     var calcDv2 = 0;
@@ -389,27 +443,35 @@ class GetUtils {
       calcDv2 += digits[j++] * i;
     }
     calcDv2 %= 11;
-    var dv2 = calcDv2 < 2 ? 0 : 11 - calcDv2;
+    final dv2 = calcDv2 < 2 ? 0 : 11 - calcDv2;
 
     // Testar o segundo dígito verificador
-    if (digits[13] != dv2) return false;
+    if (digits[13] != dv2) {
+      return false;
+    }
 
     return true;
   }
 
   /// Checks if the cpf is valid.
   static bool isCpf(String cpf) {
-    if (cpf == null) return false;
+    if (cpf == null) {
+      return false;
+    }
 
     // get only the numbers
-    var numbers = cpf.replaceAll(RegExp(r'[^0-9]'), '');
+    final numbers = cpf.replaceAll(RegExp(r'[^0-9]'), '');
     // Test if the CPF has 11 digits
-    if (numbers.length != 11) return false;
+    if (numbers.length != 11) {
+      return false;
+    }
     // Test if all CPF digits are the same
-    if (RegExp(r'^(\d)\1*$').hasMatch(numbers)) return false;
+    if (RegExp(r'^(\d)\1*$').hasMatch(numbers)) {
+      return false;
+    }
 
     // split the digits
-    var digits = numbers.split('').map(int.parse).toList();
+    final digits = numbers.split('').map(int.parse).toList();
 
     // Calculate the first verifier digit
     var calcDv1 = 0;
@@ -417,10 +479,13 @@ class GetUtils {
       calcDv1 += digits[10 - i] * i;
     }
     calcDv1 %= 11;
-    var dv1 = calcDv1 < 2 ? 0 : 11 - calcDv1;
+
+    final dv1 = calcDv1 < 2 ? 0 : 11 - calcDv1;
 
     // Tests the first verifier digit
-    if (digits[9] != dv1) return false;
+    if (digits[9] != dv1) {
+      return false;
+    }
 
     // Calculate the second verifier digit
     var calcDv2 = 0;
@@ -429,48 +494,64 @@ class GetUtils {
     }
     calcDv2 %= 11;
 
-    var dv2 = calcDv2 < 2 ? 0 : 11 - calcDv2;
+    final dv2 = calcDv2 < 2 ? 0 : 11 - calcDv2;
 
     // Test the second verifier digit
-    if (digits[10] != dv2) return false;
+    if (digits[10] != dv2) {
+      return false;
+    }
 
     return true;
   }
 
   /// Capitalize each word inside string
   /// Example: your name => Your Name, your name => Your name
-  static String capitalize(String s) {
-    if (isNullOrBlank(s)) return null;
+  static String capitalize(String value) {
+    if (isNullOrBlank(value)) {
+      return null;
+    }
 
-    var separatedWords = s.split(' ');
+    final separatedWords = value.split(' ');
     var result = '';
+
     for (var word in separatedWords) {
       result += capitalizeFirst(word);
       result += ' ';
     }
+
     return result.trim();
   }
 
   /// Uppercase first letter inside string and let the others lowercase
   /// Example: your name => Your name
   static String capitalizeFirst(String s) {
-    if (isNullOrBlank(s)) return null;
+    if (isNullOrBlank(s)) {
+      return null;
+    }
+
     return s[0].toUpperCase() + s.substring(1).toLowerCase();
   }
 
   /// Remove all whitespace inside string
   /// Example: your name => yourname
-  static String removeAllWhitespace(String s) {
-    if (isNullOrBlank(s)) return null;
-    return s.replaceAll(' ', '');
+  static String removeAllWhitespace(String value) {
+    if (isNullOrBlank(value)) {
+      return null;
+    }
+
+    return value.replaceAll(' ', '');
   }
 
   /// Camelcase string
   /// Example: your name => yourName
-  static String camelCase(String s) {
-    if (isNullOrBlank(s)) return null;
-    var separatedWords = s.split(' ');
+  static String camelCase(String value) {
+    if (isNullOrBlank(value)) {
+      return null;
+    }
+
+    final separatedWords = value.split(' ');
     var newString = '';
+
     for (final word in separatedWords) {
       newString += word[0].toUpperCase() + word.substring(1).toLowerCase();
     }
@@ -484,10 +565,16 @@ class GetUtils {
   /// (first found numeric word)
   static String numericOnly(String s, {bool firstWordOnly = false}) {
     var numericOnlyStr = '';
+
     for (var i = 0; i < s.length; i++) {
-      if (isNumericOnly(s[i])) numericOnlyStr += s[i];
-      if (firstWordOnly && numericOnlyStr.isNotEmpty && s[i] == " ") break;
+      if (isNumericOnly(s[i])) {
+        numericOnlyStr += s[i];
+      }
+      if (firstWordOnly && numericOnlyStr.isNotEmpty && s[i] == " ") {
+        break;
+      }
     }
+
     return numericOnlyStr;
   }
 
@@ -495,7 +582,12 @@ class GetUtils {
     return (value == null) ? false : RegExp(pattern).hasMatch(value);
   }
 
-  static void printFunction(String prefix, dynamic value, String info,
-          {bool isError = false}) =>
-      GetConfig.log('$prefix $value $info'.trim(), isError: isError);
+  static void printFunction(
+    String prefix,
+    dynamic value,
+    String info, {
+    bool isError = false,
+  }) {
+    GetConfig.log('$prefix $value $info'.trim(), isError: isError);
+  }
 }

--- a/test/src/extensions/dynamic_extensions_test.dart
+++ b/test/src/extensions/dynamic_extensions_test.dart
@@ -8,60 +8,63 @@ class TestClass {
 class EmptyClass {}
 
 void main() {
-  group('dynamic extensions', () {
-    test('var.isNullOrBlank on a string ', () {
-      var string = '';
-      expect('foo'.isNullOrBlank, equals(false));
-      expect(string.isNullOrBlank, equals(true));
-    });
-    test('var.isNullOrBlank on a int ', () {
-      expect(5.isNullOrBlank, equals(false));
-      expect(0.isNullOrBlank, equals(false));
+  group('isNullOrBlank on dynamic', () {
+    // Identity util to convert to iterables
+    dynamic _id(dynamic e) => e;
+
+    test('null isNullOrBlank should be true for null', () {
+      expect((null).isNullOrBlank, true);
     });
 
-    test('var.isNullOrBlank on a double ', () {
+    test('isNullOrBlank should be false for unsupported types', () {
+      expect(5.isNullOrBlank, false);
+      expect(0.isNullOrBlank, false);
+
       expect(5.0.isNullOrBlank, equals(false));
       expect(0.0.isNullOrBlank, equals(false));
-    });
 
-    test('var.isNullOrBlank on a list ', () {
-      var list = ['foo'];
-      expect([].isNullOrBlank, equals(true));
-      expect(['oi', 'foo'].isNullOrBlank, equals(false));
-      expect([{}, {}].isNullOrBlank, equals(false));
-      expect(list[0].isNullOrBlank, equals(false));
-    });
-
-    test('var.isNullOrBlank on a set ', () {
-      var halogens = {'fluorine', 'chlorine', 'bromine', 'iodine', 'astatine'};
-      expect(<String>{}.isNullOrBlank, equals(true));
-      expect({'foo', 'bar'}.isNullOrBlank, equals(false));
-      expect(halogens.isNullOrBlank, equals(false));
-    });
-
-    test('var.isNullOrBlank on a map ', () {
-      var map = {"foo": 'bar', "one": "um"};
-      expect({}.isNullOrBlank, equals(true));
-      expect({"other": "thing"}.isNullOrBlank, equals(false));
-      expect({'first': [], 'second': []}.isNullOrBlank, equals(false));
-      expect(map["foo"].isNullOrBlank, equals(false));
-      expect(map["other"].isNullOrBlank, equals(true));
-    });
-
-    test('var.isNullOrBlank on a function ', () {
-      someFunction({String string, int integer}) {
-        expect(string.isNullOrBlank, equals(false));
-        expect(integer.isNullOrBlank, equals(true));
-      }
-
-      someFunction(string: 'some value');
-    });
-
-    test('var.isNullOrBlank on a class ', () {
       TestClass testClass;
-      expect(TestClass().isNullOrBlank, equals(false));
       expect(testClass.isNullOrBlank, equals(true));
+      expect(TestClass().isNullOrBlank, equals(false));
       expect(EmptyClass().isNullOrBlank, equals(false));
+    });
+
+    test('isNullOrBlank should validate strings', () {
+      expect("".isNullOrBlank, true);
+      expect("  ".isNullOrBlank, true);
+
+      expect("foo".isNullOrBlank, false);
+      expect(" foo ".isNullOrBlank, false);
+
+      expect("null".isNullOrBlank, false);
+    });
+
+    test('isNullOrBlank should validate iterables', () {
+      expect([].map(_id).isNullOrBlank, true);
+      expect([1].map(_id).isNullOrBlank, false);
+    });
+
+    test('isNullOrBlank should validate lists', () {
+      expect([].isNullOrBlank, true);
+      expect(['oi', 'foo'].isNullOrBlank, false);
+      expect([{}, {}].isNullOrBlank, false);
+      expect(['foo'][0].isNullOrBlank, false);
+    });
+
+    test('isNullOrBlank should validate sets', () {
+      expect((<dynamic>{}).isNullOrBlank, true);
+      expect(({1}).isNullOrBlank, false);
+      expect({'fluorine', 'chlorine', 'bromine'}.isNullOrBlank, false);
+    });
+
+    test('isNullOrBlank should validate maps', () {
+      expect(({}).isNullOrBlank, true);
+      expect(({1: 1}).isNullOrBlank, false);
+      expect({"other": "thing"}.isNullOrBlank, false);
+
+      final map = {"foo": 'bar', "one": "um"};
+      expect(map["foo"].isNullOrBlank, false);
+      expect(map["other"].isNullOrBlank, true);
     });
   });
 

--- a/test/src/utils/get_utils_test.dart
+++ b/test/src/utils/get_utils_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+
+// Identity util to convert to iterables
+dynamic _id(dynamic e) => e;
+
+void main() {
+  // Tests for GetUtils.isNullOrBlank are located at dynamic extensions
+  group('GetUtils.isLength* functions', () {
+    test('isLengthEqualTo should validate iterable lengths', () {
+      // iterables should cover list and set
+      expect(GetUtils.isLengthEqualTo([].map(_id), 0), true);
+      expect(GetUtils.isLengthEqualTo([1, 2].map(_id), 2), true);
+
+      expect(GetUtils.isLengthEqualTo({}, 0), true);
+      expect(GetUtils.isLengthEqualTo({1: 1, 2: 1}, 2), true);
+      expect(GetUtils.isLengthEqualTo({}, 2), false);
+
+      expect(GetUtils.isLengthEqualTo("", 0), true);
+      expect(GetUtils.isLengthEqualTo("a", 0), false);
+      expect(GetUtils.isLengthEqualTo("a", 1), true);
+    });
+
+    test('isLengthGreaterOrEqual should validate lengths', () {
+      // iterables should cover list and set
+      expect(GetUtils.isLengthGreaterOrEqual([].map(_id), 0), true);
+      expect(GetUtils.isLengthGreaterOrEqual([1, 2].map(_id), 2), true);
+      expect(GetUtils.isLengthGreaterOrEqual([1, 2].map(_id), 1), true);
+
+      expect(GetUtils.isLengthGreaterOrEqual({}, 0), true);
+      expect(GetUtils.isLengthGreaterOrEqual({1: 1, 2: 1}, 1), true);
+      expect(GetUtils.isLengthGreaterOrEqual({1: 1, 2: 1}, 2), true);
+      expect(GetUtils.isLengthGreaterOrEqual({}, 2), false);
+
+      expect(GetUtils.isLengthGreaterOrEqual("", 0), true);
+      expect(GetUtils.isLengthGreaterOrEqual("a", 0), true);
+      expect(GetUtils.isLengthGreaterOrEqual("", 1), false);
+    });
+
+    test('isLengthLessOrEqual should validate lengths', () {
+      // iterables should cover list and set
+      expect(GetUtils.isLengthLessOrEqual([].map(_id), 0), true);
+      expect(GetUtils.isLengthLessOrEqual([1, 2].map(_id), 2), true);
+      expect(GetUtils.isLengthLessOrEqual([1, 2].map(_id), 1), false);
+
+      expect(GetUtils.isLengthLessOrEqual({}, 0), true);
+      expect(GetUtils.isLengthLessOrEqual({1: 1, 2: 1}, 1), false);
+      expect(GetUtils.isLengthLessOrEqual({1: 1, 2: 1}, 3), true);
+      expect(GetUtils.isLengthLessOrEqual({}, 2), true);
+
+      expect(GetUtils.isLengthLessOrEqual("", 0), true);
+      expect(GetUtils.isLengthLessOrEqual("a", 2), true);
+      expect(GetUtils.isLengthLessOrEqual("a", 0), false);
+    });
+  });
+}


### PR DESCRIPTION
This PR fixes the missing functions that were using 'switch types' (I've made a comment in #591), I've also **deprecated** the `isLengthLowerThan` and `isLengthLowerOrEqual` functions, I've **renamed** them to `isLengthLessThan` and `isLengthLessOrEqual` respectively.

I've also added some tests, I would add tests for all fns but there's a lot to test 😭...  perhaps they can be added by need..