### PR TITLE
RxList null check in the constructor

### DIFF
--- a/lib/src/state_manager/rx/rx_iterables/rx_list.dart
+++ b/lib/src/state_manager/rx/rx_iterables/rx_list.dart
@@ -11,7 +11,7 @@ import '../rx_typedefs/rx_typedefs.dart';
 /// Create a list similar to `List<T>`
 class RxList<E> implements List<E>, RxInterface<List<E>> {
   RxList([List<E> initial]) {
-    _list = initial ?? [];
+    if (initial != null) _list = initial;
   }
 
   List<E> _list = <E>[];

--- a/lib/src/state_manager/rx/rx_iterables/rx_list.dart
+++ b/lib/src/state_manager/rx/rx_iterables/rx_list.dart
@@ -11,7 +11,7 @@ import '../rx_typedefs/rx_typedefs.dart';
 /// Create a list similar to `List<T>`
 class RxList<E> implements List<E>, RxInterface<List<E>> {
   RxList([List<E> initial]) {
-    _list = initial;
+    _list = initial ?? [];
   }
 
   List<E> _list = <E>[];

--- a/lib/src/state_manager/rx/rx_iterables/rx_map.dart
+++ b/lib/src/state_manager/rx/rx_iterables/rx_map.dart
@@ -9,7 +9,7 @@ import '../rx_typedefs/rx_typedefs.dart';
 
 class RxMap<K, V> implements RxInterface<Map<K, V>>, Map<K, V> {
   RxMap([Map<K, V> initial]) {
-    _value = initial;
+    if (initial != null) _value = initial;
   }
 
   @override

--- a/lib/src/state_manager/rx/rx_iterables/rx_set.dart
+++ b/lib/src/state_manager/rx/rx_iterables/rx_set.dart
@@ -9,7 +9,7 @@ import '../rx_typedefs/rx_typedefs.dart';
 
 class RxSet<E> implements Set<E>, RxInterface<Set<E>> {
   RxSet([Set<E> initial]) {
-    _set = initial;
+    if (initial != null) _set = initial;
   }
 
   Set<E> _set = <E>{};


### PR DESCRIPTION
If RxList is instantiated with the constructor without provide the optional parameter:
`RxList([List<E> initial])`
Like:
`RxList<Foo> foo = RxList();`
the constructor will override the property "_list" with a null.
This can cause null pointer exception on methods such as
isEmpty
isNotEmpty
An easy fix is to pass an empty list to the constructor:
`RxList<Foo> rxList = RxList([]);`
But that isn't a good solution, the linter will not flat the use of the constructor without the optional value.
