### PR TITLE
Retirada de código desnecessário no exemplo

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,6 @@ return GetMaterialApp(
     translations: Messages(), // your translations
     locale: Locale('en', 'US'), // translations will be displayed in that locale
     fallbackLocale: Locale('en', 'UK'), // specify the fallback locale in case an invalid locale is selected.
-    supportedLocales: <Locale>[Locale('en', 'UK'),  Locale('en', 'US'), Locale('de','DE')] // specify the supported locales
 );
 ```
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -345,7 +345,6 @@ return GetMaterialApp(
     translations: Messages(), // suas traduções
     locale: Locale('en', 'US'), // as traduções serão exibidas para esta localidade
     fallbackLocale: Locale('en', 'UK'), // especifica uma localidade em caso de falha na localidade definida
-    supportedLocales: <Locale>[Locale('en', 'UK'),  Locale('en', 'US'), Locale('de','DE')] // especifica as localidades suportados
 );
 ```
 


### PR DESCRIPTION
- Exclusão de um trecho de código de exemplo referente a internacionalização, pois ele não é necessário especificamente para GetX e ainda pode provocar issues desnecessárias, caso alguém teste a inclusão de outras línguas nessa propriedade, como pt_BR, já que essa não é suportada, causando uma exceção, e necessitaria da inclusão do package `flutter_localizations` e mais configurações em GetMaterialApp. Em resumo, a internacionalização e a troca do locale funcionam normalmente no GetX sem a necessidade do uso da propriedade supportedLocales em GetMaterialApp