### PR TITLE
fix(unknownRoute): Fix customTransition being called on null

### DIFF
--- a/packages/get_navigation/lib/src/root/root_widget.dart
+++ b/packages/get_navigation/lib/src/root/root_widget.dart
@@ -126,7 +126,7 @@ class GetMaterialApp extends StatelessWidget {
             RouteSettings(name: settings.name, arguments: settings.arguments),
         curve: unknownRoute.curve,
         opaque: unknownRoute.opaque,
-        customTransition: match.route.customTransition,
+        customTransition: unknownRoute.customTransition,
         binding: unknownRoute.binding,
         bindings: unknownRoute.bindings,
         transitionDuration:


### PR DESCRIPTION
CustomTransition being called on null when opening unknown route