### PR TITLE
Fixes Get.create() and GetWidget()

### DIFF
--- a/packages/get_instance/lib/src/extension_instance.dart
+++ b/packages/get_instance/lib/src/extension_instance.dart
@@ -1,4 +1,5 @@
 import 'package:get_core/get_core.dart';
+
 import 'get_instance.dart';
 
 extension Inst on GetInterface {
@@ -47,6 +48,7 @@ extension Inst on GetInterface {
   /// So, if you call `Get.delete<T>()` the "instance factory" used in this
   /// method ([Get.create<T>()]) will be removed, but NOT the instances
   /// already created by it.
+  /// Uses `tag` as the other methods.
   ///
   /// Example:
   ///
@@ -55,8 +57,8 @@ extension Inst on GetInterface {
   /// Repl b = find();
   /// print(a==b); (false)```
   void create<S>(InstanceBuilderCallback<S> builder,
-          {String name, bool permanent = true}) =>
-      GetInstance().create<S>(builder, name: name, permanent: permanent);
+          {String tag, bool permanent = true}) =>
+      GetInstance().create<S>(builder, tag: tag, permanent: permanent);
 
   /// Finds a Instance of the required Class <[S]>(or [tag])
   /// In the case of using [Get.create()], it will generate an Instance

--- a/packages/get_instance/lib/src/get_instance.dart
+++ b/packages/get_instance/lib/src/get_instance.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:collection';
+
 import 'package:get_core/get_core.dart';
+
 import 'lifecircle.dart';
 
 class GetInstance {
@@ -178,11 +180,14 @@ class GetInstance {
   /// [Get.keepFactory]
   /// Only flags `isInit` if it's using `Get.create()`
   /// (not for Singletons access).
-  bool _initDependencies<S>({String name}) {
+  /// Returns the instance if not initialized, required for Get.create() to
+  /// work properly.
+  S _initDependencies<S>({String name}) {
     final key = _getKey(S, name);
     final isInit = _singl[key].isInit;
+    S i;
     if (!isInit) {
-      _startController<S>(tag: name);
+      i = _startController<S>(tag: name);
       if (_singl[key].isSingleton) {
         _singl[key].isInit = true;
         if (Get.smartManagement != SmartManagement.onlyBuilder) {
@@ -190,7 +195,7 @@ class GetInstance {
         }
       }
     }
-    return true;
+    return i;
   }
 
   /// Links a Class instance [S] (or [tag]) to the current route.
@@ -206,9 +211,9 @@ class GetInstance {
   }
 
   /// Initializes the controller
-  void _startController<S>({String tag}) {
+  S _startController<S>({String tag}) {
     final key = _getKey(S, tag);
-    final i = _singl[key].getDependency();
+    final i = _singl[key].getDependency() as S;
     if (i is GetLifeCycle) {
       if (i.onStart != null) {
         i.onStart();
@@ -219,6 +224,7 @@ class GetInstance {
         _routesByCreate[Get.reference].add(i.onClose);
       }
     }
+    return i;
   }
 
   // S putOrFind<S>(S Function() dep, {String tag}) {
@@ -257,8 +263,12 @@ class GetInstance {
           throw 'Class "$S" with tag "$tag" is not register';
         }
       }
-      _initDependencies<S>(name: tag);
-      return _singl[key].getDependency() as S;
+
+      /// although dirty solution, the lifecycle starts inside
+      /// `initDependencies`, so we have to return the instance from there
+      /// to make it compatible with `Get.create()`.
+      final i = _initDependencies<S>(name: tag);
+      return i ?? _singl[key].getDependency() as S;
     } else {
       if (!_factory.containsKey(key)) {
         // ignore: lines_longer_than_80_chars

--- a/packages/get_instance/lib/src/get_instance.dart
+++ b/packages/get_instance/lib/src/get_instance.dart
@@ -116,11 +116,11 @@ class GetInstance {
   /// print(a==b); (false)```
   void create<S>(
     InstanceBuilderCallback<S> builder, {
-    String name,
+    String tag,
     bool permanent = true,
   }) {
     _insert(
-        isSingleton: false, name: name, builder: builder, permanent: permanent);
+        isSingleton: false, name: tag, builder: builder, permanent: permanent);
   }
 
   /// Injects the Instance [S] builder into the [_singleton] HashMap.

--- a/packages/get_state_manager/lib/src/simple/get_view.dart
+++ b/packages/get_state_manager/lib/src/simple/get_view.dart
@@ -11,9 +11,13 @@ import 'package:get_instance/get_instance.dart';
 /// }
 ///
 /// class AwesomeView extends GetView<AwesomeController> {
-///   /// if you need you can pass the tag for your controller
-///   /// in the super constructor.
-///   AwesomeView({Key key}):super(key:key, tag:"myControllerTag");
+///   /// if you need you can pass the tag for
+///   /// Get.find<AwesomeController>(tag:"myTag");
+///   @override
+///   final String tag = "myTag";
+///
+///   AwesomeView({Key key}):super(key:key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return Container(
@@ -24,9 +28,9 @@ import 'package:get_instance/get_instance.dart';
 /// }
 ///``
 abstract class GetView<T> extends StatelessWidget {
-  const GetView({Key key, this.tag}) : super(key: key);
+  const GetView({Key key}) : super(key: key);
 
-  final String tag;
+  final String tag = null;
 
   T get controller => GetInstance().find<T>(tag: tag);
 

--- a/packages/get_state_manager/lib/src/simple/get_view.dart
+++ b/packages/get_state_manager/lib/src/simple/get_view.dart
@@ -11,6 +11,9 @@ import 'package:get_instance/get_instance.dart';
 /// }
 ///
 /// class AwesomeView extends GetView<AwesomeController> {
+///   /// if you need you can pass the tag for your controller
+///   /// in the super constructor.
+///   AwesomeView({Key key}):super(key:key, tag:"myControllerTag");
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return Container(
@@ -21,9 +24,9 @@ import 'package:get_instance/get_instance.dart';
 /// }
 ///``
 abstract class GetView<T> extends StatelessWidget {
-  const GetView({Key key}) : super(key: key);
+  const GetView({Key key, this.tag}) : super(key: key);
 
-  final String tag = null;
+  final String tag;
 
   T get controller => GetInstance().find<T>(tag: tag);
 


### PR DESCRIPTION
- Although "nasty" solution, multiple instances were created with one Get.find() when using Get.create(), now the actual instance created from `GetInstance::<S>_startController()` > `GetInstance::<S>_initDependencies()` > `GetInstance::<S>_find()` is returned.
- added docs and impl to `GetWidget` to make it work with **DI** `tag`, I place it in the constructor directly (to use with `:super( tag: "something")` )... but we might actually use an override getter as well if needed.