### PR TITLE
typedef over dynamic Function for GetX/GetBuilder builders

### DIFF
--- a/packages/get_state_manager/lib/src/rx_flutter/rx_getx_widget.dart
+++ b/packages/get_state_manager/lib/src/rx_flutter/rx_getx_widget.dart
@@ -6,8 +6,11 @@ import 'package:get_instance/get_instance.dart';
 import 'package:get_rx/get_rx.dart';
 import '../../get_state_manager.dart';
 
+typedef GetXControllerBuilder<T extends DisposableInterface> = Widget Function(
+    T controller);
+
 class GetX<T extends DisposableInterface> extends StatefulWidget {
-  final Widget Function(T) builder;
+  final GetXControllerBuilder<T> builder;
   final bool global;
 
   // final Stream Function(T) stream;

--- a/packages/get_state_manager/lib/src/simple/get_state.dart
+++ b/packages/get_state_manager/lib/src/simple/get_state.dart
@@ -123,8 +123,11 @@ class GetxController extends DisposableInterface {
   /// }
 }
 
+typedef GetControllerBuilder<T extends DisposableInterface> = Widget Function(
+    T controller);
+
 class GetBuilder<T extends GetxController> extends StatefulWidget {
-  final Widget Function(T) builder;
+  final GetControllerBuilder<T> builder;
   final bool global;
   final String id;
   final String tag;


### PR DESCRIPTION
- both GetX and GetBuilder
- now typesafe return instead of empty Function

Now allows for Dart to automatically autofill the required parameter value, whereas before it returned a dynamic Function with no parameter.
![Code 2020-09-29 at 13 40 27](https://user-images.githubusercontent.com/6836556/94510749-e0659d00-025a-11eb-9513-a645aaecb46e.png)
After:
![Code 2020-09-29 at 13 40 45](https://user-images.githubusercontent.com/6836556/94510760-e78cab00-025a-11eb-8914-6fdb1a087bce.png)

