### PR TITLE
Fix null route error

### DIFF
--- a/documentation/en_US/route_management.md
+++ b/documentation/en_US/route_management.md
@@ -152,6 +152,23 @@ void main() {
 }
 ```
 
+To handle navigation to non-defined routes (404 error), you can define an unknownRoute page in GetMaterialApp.
+
+```dart
+void main() {
+  runApp(
+    GetMaterialApp(
+      unknownRoute: GetPage(name: '/notfound', page: () => UnknownRoutePage()),
+      initialRoute: '/',
+      getPages: [
+        GetPage(name: '/', page: () => MyHomePage()),
+        GetPage(name: '/second', page: () => Second()),
+      ],
+    )
+  );
+}
+```
+
 ### Send data to named Routes
 
 Just send what you want for arguments. Get accepts anything here, whether it is a String, a Map, a List, or even a class instance.

--- a/documentation/es_ES/route_management.md
+++ b/documentation/es_ES/route_management.md
@@ -151,6 +151,23 @@ void main() {
 }
 ```
 
+Para manejar la navegación a rutas no definidas (error 404), puede definir una página de ruta desconocida en GetMaterialApp.
+
+```dart
+void main() {
+  runApp(
+    GetMaterialApp(
+      unknownRoute: GetPage(name: '/notfound', page: () => UnknownRoutePage()),
+      initialRoute: '/',
+      getPages: [
+        GetPage(name: '/', page: () => MyHomePage()),
+        GetPage(name: '/second', page: () => Second()),
+      ],
+    )
+  );
+}
+```
+
 ### Enviar datos a rutas nombradas
 
 Envía lo que quieras usando el parámetro arguments. GetX acepta cualquier cosa aquí, ya sea un String, Map, List o incluso una instancia de clase.

--- a/documentation/pt_BR/route_management.md
+++ b/documentation/pt_BR/route_management.md
@@ -247,6 +247,23 @@ void main() {
 }
 ```
 
+Para lidar com a navegação para rotas não definidas (erro 404), você pode definir uma página unknownRoute em GetMaterialApp.
+
+```dart
+void main() {
+  runApp(
+    GetMaterialApp(
+      unknownRoute: GetPage(name: '/notfound', page: () => UnknownRoutePage()),
+      initialRoute: '/',
+      getPages: [
+        GetPage(name: '/', page: () => MyHomePage()),
+        GetPage(name: '/second', page: () => Second()),
+      ],
+    )
+  );
+}
+```
+
 ### Enviar dados para rotas nomeadas
 
 Apenas envie o que você quiser no parâmetro `arguments`. Get aceita qualquer coisa aqui, seja String, Map, List, ou até a instância de uma classe.

--- a/documentation/zh_CN/route_management.md
+++ b/documentation/zh_CN/route_management.md
@@ -149,6 +149,23 @@ void main() {
 }
 ```
 
+要处理到未定义路线的导航（404错误），可以在GetMaterialApp中定义unknownRoute页面。
+
+```dart
+void main() {
+  runApp(
+    GetMaterialApp(
+      unknownRoute: GetPage(name: '/notfound', page: () => UnknownRoutePage()),
+      initialRoute: '/',
+      getPages: [
+        GetPage(name: '/', page: () => MyHomePage()),
+        GetPage(name: '/second', page: () => Second()),
+      ],
+    )
+  );
+}
+```
+
 ### 发送数据到别名路由
 
 只要发送你想要的参数即可。Get在这里接受任何东西，无论是一个字符串，一个Map，一个List，甚至一个类的实例。

--- a/packages/get_navigation/lib/src/root/root_widget.dart
+++ b/packages/get_navigation/lib/src/root/root_widget.dart
@@ -161,6 +161,27 @@ class GetMaterialApp extends StatelessWidget {
     final match = Get.routeTree.matchRoute(name);
     Get.parameters = match?.parameters;
 
+    //Route can be nullable, just pass the initial route
+    if (match?.route == null) {
+      return [
+        GetPageRoute(
+          page: unknownRoute.page,
+          parameter: unknownRoute.parameter,
+          settings: RouteSettings(name: name, arguments: null),
+          curve: unknownRoute.curve,
+          opaque: unknownRoute.opaque,
+          customTransition: unknownRoute.customTransition,
+          binding: unknownRoute.binding,
+          bindings: unknownRoute.bindings,
+          transitionDuration: (unknownRoute.transitionDuration ??
+              Get.defaultTransitionDuration),
+          transition: unknownRoute.transition,
+          popGesture: unknownRoute.popGesture,
+          fullscreenDialog: unknownRoute.fullscreenDialog,
+        )
+      ];
+    }
+
     return [
       GetPageRoute(
         page: match.route.page,


### PR DESCRIPTION
This was using flutter web.
I encountered an error in which I was redirected back to my site, I had 2 issues (1 I could not solve, will make an issue),
the other, caused an error in which `match.route` was null on `initialRoutesGenerate`, and members were being accessed on a null field. This would show the default browser 404 page, even though an unknown route was setup.

This will show the unknown route in that case.

I have also updated the navigation doc to let new users know to setup an unknown route.