### PR TITLE
Get life cycle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,13 @@
 #The name of your workflow.
-name:  build
+name: build
 # Trigger the workflow on push or pull request
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 #A workflow run is made up of one or more jobs. Jobs run in parallel by default.
 jobs:
-
   test:
     #The type of machine to run the job on. [windows,macos, ubuntu , self-hosted]
     defaults:
@@ -24,8 +23,8 @@ jobs:
       # https://github.com/marketplace/actions/flutter-action
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '1.20.4'
-          channel: 'stable'
+          flutter-version: "1.22.2"
+          channel: "stable"
       - run: flutter pub get
       #- run: flutter analyze
       # run  flutter widgets tests  and unit tests
@@ -33,4 +32,3 @@ jobs:
       # Upload coverage reports to Codecov
       # https://github.com/marketplace/actions/codecov
       - uses: codecov/codecov-action@v1.0.7
-

--- a/example/lib/pages/home/presentation/controllers/home_controller.dart
+++ b/example/lib/pages/home/presentation/controllers/home_controller.dart
@@ -19,7 +19,10 @@ class HomeController extends GetxController {
 
   /// When the controller is initialized, make the http request
   @override
-  void onInit() => fetchDataFromApi();
+  void onInit() {
+    super.onInit();
+    fetchDataFromApi();
+  }
 
   /// fetch cases from Api
   Future<void> fetchDataFromApi() async {

--- a/example/test/main_test.dart
+++ b/example/test/main_test.dart
@@ -170,6 +170,7 @@ class Controller extends GetxController {
     super.onReady();
   }
 
+  @override
   void onClose() {
     print('onClose');
   }

--- a/example/test/main_test.dart
+++ b/example/test/main_test.dart
@@ -172,6 +172,7 @@ class Controller extends GetxController {
 
   @override
   void onClose() {
+    super.onClose();
     print('onClose');
   }
 }

--- a/lib/get_core/get_core.dart
+++ b/lib/get_core/get_core.dart
@@ -5,3 +5,5 @@ export 'src/get_main.dart';
 export 'src/log.dart';
 
 export 'src/smart_management.dart';
+
+export 'src/typedefs.dart';

--- a/lib/get_core/src/typedefs.dart
+++ b/lib/get_core/src/typedefs.dart
@@ -1,0 +1,1 @@
+typedef ValueUpdater<T> = T Function();

--- a/lib/get_instance/src/lifecycle.dart
+++ b/lib/get_instance/src/lifecycle.dart
@@ -1,13 +1,14 @@
-import 'package:flutter/material.dart';
+import 'package:meta/meta.dart';
+import '../../get_core/get_core.dart';
 
 /// Special callable class to keep the contract of a regular method, and avoid
 /// overrides if you extend the class that uses it, as Dart has no final
 /// methods.
 /// Used in [DisposableInterface] to avoid the danger of overriding onStart.
 class _InternalFinalCallback<T> {
-  ValueGetter<T> _callback;
+  ValueUpdater<T> _callback;
 
-  _InternalFinalCallback({ValueGetter<T> callback}) : _callback = callback;
+  _InternalFinalCallback({ValueUpdater<T> callback}) : _callback = callback;
 
   T call() => _callback.call();
 }

--- a/lib/get_instance/src/lifecycle.dart
+++ b/lib/get_instance/src/lifecycle.dart
@@ -48,6 +48,7 @@ mixin GetLifeCycle {
   /// Called 1 frame after onInit(). It is the perfect place to enter
   /// navigation events, like snackbar, dialogs, or a new route, or
   /// async request.
+  @mustCallSuper
   void onReady() {}
 
   /// Called before [onDelete] method. [onClose] might be used to
@@ -56,6 +57,7 @@ mixin GetLifeCycle {
   /// Or dispose objects that can potentially create some memory leaks,
   /// like TextEditingControllers, AnimationControllers.
   /// Might be useful as well to persist some data on disk.
+  @mustCallSuper
   void onClose() {}
 
   bool _initialized = false;

--- a/lib/get_instance/src/lifecycle.dart
+++ b/lib/get_instance/src/lifecycle.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+
 /// Special callable class to keep the contract of a regular method, and avoid
 /// overrides if you extend the class that uses it, as Dart has no final
 /// methods.
@@ -6,23 +8,35 @@
 class _InternalFinalCallback<T> {
   T Function() callback;
 
-  _InternalFinalCallback();
+  _InternalFinalCallback({this.callback});
 
   T call() => callback.call();
 }
 
-mixin  GetLifeCycle {
+class _InternalFinalPrivateCallback<T> {
+  T Function() _callback;
+
+  _InternalFinalPrivateCallback();
+
+  T call() => _callback.call();
+}
+
+mixin GetLifeCycle {
   /// Called at the exact moment the widget is allocated in memory.
   /// It uses an internal "callable" type, to avoid any @overrides in subclases.
   /// This method should be internal and is required to define the
   /// lifetime cycle of the subclass.
   final onStart = _InternalFinalCallback<void>();
 
-  final onDelete = _InternalFinalCallback<void>();
+  /// Internal callback that starts the cycle of this controller.
+  final onDelete = _InternalFinalPrivateCallback<void>();
 
   /// Called immediately after the widget is allocated in memory.
   /// You might use this to initialize something for the controller.
-  void onInit() {}
+  @mustCallSuper
+  void onInit() {
+    onDelete._callback = _onDelete;
+  }
 
   /// Called 1 frame after onInit(). It is the perfect place to enter
   /// navigation events, like snackbar, dialogs, or a new route, or
@@ -36,6 +50,18 @@ mixin  GetLifeCycle {
   /// like TextEditingControllers, AnimationControllers.
   /// Might be useful as well to persist some data on disk.
   void onClose() {}
+
+  bool _isClosed = false;
+
+  /// Checks whether the controller has already been closed.
+  bool get isClosed => _isClosed;
+
+  // Internal callback that starts the cycle of this controller.
+  void _onDelete() {
+    if (_isClosed) return;
+    _isClosed = true;
+    onClose();
+  }
 }
 
 /// Allow track difference between GetxServices and GetxControllers

--- a/lib/get_state_manager/src/rx_flutter/rx_disposable.dart
+++ b/lib/get_state_manager/src/rx_flutter/rx_disposable.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import '../../../get_instance/src/lifecycle.dart';
 
@@ -15,14 +16,8 @@ abstract class DisposableInterface with GetLifeCycle {
   /// Checks whether the controller has already been initialized.
   bool get initialized => _initialized;
 
-  bool _isClosed = false;
-
-  /// Checks whether the controller has already been closed.
-  bool get isClosed => _isClosed;
-
   DisposableInterface() {
     onStart.callback = _onStart;
-    onDelete.callback = _onDelete;
   }
 
   // Internal callback that starts the cycle of this controller.
@@ -33,22 +28,17 @@ abstract class DisposableInterface with GetLifeCycle {
     SchedulerBinding.instance?.addPostFrameCallback((_) => onReady());
   }
 
-  // Internal callback that starts the cycle of this controller.
-  void _onDelete() {
-    if (_isClosed) return;
-    _isClosed = true;
-    onClose();
-  }
-
   /// Called immediately after the widget is allocated in memory.
   /// You might use this to initialize something for the controller.
   @override
-  void onInit() {}
+  @mustCallSuper
+  void onInit() => super.onInit();
 
   /// Called 1 frame after onInit(). It is the perfect place to enter
   /// navigation events, like snackbar, dialogs, or a new route, or
   /// async request.
   @override
+  @mustCallSuper
   void onReady() {}
 
   /// Called before [onDelete] method. [onClose] might be used to
@@ -58,5 +48,6 @@ abstract class DisposableInterface with GetLifeCycle {
   /// like TextEditingControllers, AnimationControllers.
   /// Might be useful as well to persist some data on disk.
   @override
+  @mustCallSuper
   void onClose() {}
 }

--- a/lib/get_state_manager/src/rx_flutter/rx_disposable.dart
+++ b/lib/get_state_manager/src/rx_flutter/rx_disposable.dart
@@ -11,28 +11,18 @@ import '../../../get_instance/src/lifecycle.dart';
 abstract class GetxService extends DisposableInterface with GetxServiceMixin {}
 
 abstract class DisposableInterface with GetLifeCycle {
-  bool _initialized = false;
-
-  /// Checks whether the controller has already been initialized.
-  bool get initialized => _initialized;
-
   DisposableInterface() {
-    onStart.callback = _onStart;
-  }
-
-  // Internal callback that starts the cycle of this controller.
-  void _onStart() {
-    if (_initialized) return;
-    onInit();
-    _initialized = true;
-    SchedulerBinding.instance?.addPostFrameCallback((_) => onReady());
+    initLifeCycle();
   }
 
   /// Called immediately after the widget is allocated in memory.
   /// You might use this to initialize something for the controller.
   @override
   @mustCallSuper
-  void onInit() => super.onInit();
+  void onInit() {
+    super.onInit();
+    SchedulerBinding.instance?.addPostFrameCallback((_) => onReady());
+  }
 
   /// Called 1 frame after onInit(). It is the perfect place to enter
   /// navigation events, like snackbar, dialogs, or a new route, or
@@ -48,6 +38,5 @@ abstract class DisposableInterface with GetLifeCycle {
   /// like TextEditingControllers, AnimationControllers.
   /// Might be useful as well to persist some data on disk.
   @override
-  @mustCallSuper
   void onClose() {}
 }

--- a/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
+++ b/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
@@ -38,20 +38,14 @@ typedef Condition = bool Function();
 
 abstract class GetNotifier<T> extends Value<T> with GetLifeCycle {
   GetNotifier(T initial) : super(initial) {
-    onStart.callback = _onStart;
+    initLifeCycle();
     _fillEmptyStatus();
   }
 
-  bool _initialized = false;
-
-  /// Checks whether the controller has already been initialized.
-  bool get initialized => _initialized;
-
-  // Internal callback that starts the cycle of this controller.
-  void _onStart() {
-    if (_initialized) return;
-    onInit();
-    _initialized = true;
+  @override
+  @mustCallSuper
+  void onInit() {
+    super.onInit();
     SchedulerBinding.instance?.addPostFrameCallback((_) => onReady());
   }
 

--- a/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
+++ b/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
@@ -39,7 +39,6 @@ typedef Condition = bool Function();
 abstract class GetNotifier<T> extends Value<T> with GetLifeCycle {
   GetNotifier(T initial) : super(initial) {
     onStart.callback = _onStart;
-    onDelete.callback = _onDelete;
     _fillEmptyStatus();
   }
 
@@ -48,24 +47,12 @@ abstract class GetNotifier<T> extends Value<T> with GetLifeCycle {
   /// Checks whether the controller has already been initialized.
   bool get initialized => _initialized;
 
-  bool _isClosed = false;
-
-  /// Checks whether the controller has already been closed.
-  bool get isClosed => _isClosed;
-
   // Internal callback that starts the cycle of this controller.
   void _onStart() {
     if (_initialized) return;
     onInit();
     _initialized = true;
     SchedulerBinding.instance?.addPostFrameCallback((_) => onReady());
-  }
-
-  // Internal callback that starts the cycle of this controller.
-  void _onDelete() {
-    if (_isClosed) return;
-    _isClosed = true;
-    onClose();
   }
 
   RxStatus _status;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  meta: 1.3.0-nullsafety.3
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 3.13.2
 homepage: https://github.com/jonataslaw/getx
 
 environment:
-  sdk: ">=2.8.0 <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/test/instance/get_instance_test.dart
+++ b/test/instance/get_instance_test.dart
@@ -12,7 +12,6 @@ class Mock {
 class DisposableController with GetLifeCycle {
   DisposableController() {
     onStart.callback = _onStart;
-    onDelete.callback = _onDelete;
   }
 
   // Internal callback that starts the cycle of this controller.
@@ -21,18 +20,13 @@ class DisposableController with GetLifeCycle {
     onInit();
   }
 
-  // Internal callback that starts the cycle of this controller.
-  void _onDelete() {
-    if (isClosed) return;
-    isClosed = true;
-    onClose();
-  }
-
   bool initialized = false;
 
   bool isClosed = false;
 
+  @override
   void onInit() async {
+    super.onInit();
     initialized = true;
   }
 }

--- a/test/instance/get_instance_test.dart
+++ b/test/instance/get_instance_test.dart
@@ -11,23 +11,7 @@ class Mock {
 
 class DisposableController with GetLifeCycle {
   DisposableController() {
-    onStart.callback = _onStart;
-  }
-
-  // Internal callback that starts the cycle of this controller.
-  void _onStart() {
-    if (initialized) return;
-    onInit();
-  }
-
-  bool initialized = false;
-
-  bool isClosed = false;
-
-  @override
-  void onInit() async {
-    super.onInit();
-    initialized = true;
+    initLifeCycle();
   }
 }
 

--- a/test/src/extensions/dynamic_extensions_test.dart
+++ b/test/src/extensions/dynamic_extensions_test.dart
@@ -73,7 +73,6 @@ void main() {
     var expected = '';
     void logFunction(String prefix, dynamic value, String info,
         {bool isError = false}) {
-      print('algo');
       expected = '$prefix $value $info'.trim();
     }
 


### PR DESCRIPTION
The `GetLifeCycle` must implement a base for the life cycle by itself instead of force to repeat yourself in every implementation.