### PR TITLE
Provide error for StateMixin obx widget

### DIFF
--- a/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
+++ b/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
@@ -122,13 +122,15 @@ abstract class GetNotifier<T> extends Value<T> with GetLifeCycleBase {
 }
 
 extension StateExt<T> on StateMixin<T> {
-  Widget obx(NotifierBuilder<T> widget, {Widget onError, Widget onLoading}) {
+  Widget obx(NotifierBuilder<T> widget, {Widget Function(String error) onError, Widget onLoading}) {
     assert(widget != null);
     return SimpleBuilder(builder: (_) {
       if (status.isLoading) {
         return onLoading ?? CircularProgressIndicator();
       } else if (status.isError) {
-        return onError ?? Text('A error occured: ${status.errorMessage}');
+        return onError != null
+            ? onError(status.errorMessage)
+            : Text('A error occured: ${status.errorMessage}');
       } else {
         return widget(value);
       }


### PR DESCRIPTION
New StateMixin: Get the error defined in `RxStatus.error` and provide for the obx widget to use in the `onError` parameter. Example:

```dart
controller.obx(
  (state) => ...,
  onError: (error) => Center(
    child: Text(
      'Error: $error',
       style: TextStyle(fontSize: 18), textAlign: TextAlign.center,
    ),
  ),
)
```