### PR TITLE
Fix incorrect Get.reference when pop route

### DIFF
--- a/lib/get_navigation/src/routes/observers/route_observer.dart
+++ b/lib/get_navigation/src/routes/observers/route_observer.dart
@@ -127,14 +127,15 @@ class GetObserver extends NavigatorObserver {
   @override
   void didPop(Route route, Route previousRoute) {
     super.didPop(route, previousRoute);
-    final newRoute = _RouteData.ofRoute(route);
+    final currentRoute = _RouteData.ofRoute(route);
+    final newRoute = _RouteData.ofRoute(previousRoute);
 
-    if (newRoute.isSnackbar) {
-      Get.log("CLOSE SNACKBAR ${newRoute.name}");
-    } else if (newRoute.isBottomSheet || newRoute.isDialog) {
-      Get.log("CLOSE ${newRoute.name}");
-    } else if (newRoute.isGetPageRoute) {
-      Get.log("CLOSE TO ROUTE ${newRoute.name}");
+    if (currentRoute.isSnackbar) {
+      Get.log("CLOSE SNACKBAR ${currentRoute.name}");
+    } else if (currentRoute.isBottomSheet || currentRoute.isDialog) {
+      Get.log("CLOSE ${currentRoute.name}");
+    } else if (currentRoute.isGetPageRoute) {
+      Get.log("CLOSE TO ROUTE ${currentRoute.name}");
     }
 
     Get.reference = newRoute.name;


### PR DESCRIPTION
When pop route, the newly active route is previousRoute.
Ref: [NavigatorObserver.didPop](https://api.flutter.dev/flutter/widgets/NavigatorObserver/didPop.html)