### PR TITLE
Adjustment in the sample code in the readme of all languages

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -125,11 +125,13 @@ class Controller extends GetxController {
 ```dart
 class Home extends StatelessWidget {
 
-  // Cree una instancia de su clase usando Get.put() para que esté disponible para todas las rutas "secundarias" allí.
-  final Controller c = Get.put(Controller());
-
   @override
-  Widget build(context) => Scaffold(
+  Widget build(context) {
+
+    // Cree una instancia de su clase usando Get.put() para que esté disponible para todas las rutas "secundarias" allí.
+    final Controller c = Get.put(Controller());
+    
+    return Scaffold(
       // Utilice Obx(()=> para actualizar Text() siempre que se cambie el recuento.
       appBar: AppBar(title: Obx(() => Text("Clicks: " + c.count.string))),
 
@@ -138,6 +140,7 @@ class Home extends StatelessWidget {
               child: Text("Go to Other"), onPressed: () => Get.to(Other()))),
       floatingActionButton:
           FloatingActionButton(child: Icon(Icons.add), onPressed: c.increment));
+  }
 }
 
 class Other extends StatelessWidget {

--- a/README.ko-kr.md
+++ b/README.ko-kr.md
@@ -123,11 +123,13 @@ class Controller extends GetxController{
 ```dart
 class Home extends StatelessWidget {
 
-  // Get.put()을 사용하여 클래스를 인스턴스화하여 모든 "child'에서 사용가능하게 합니다.
-  final Controller c = Get.put(Controller());
-
   @override
-  Widget build(context) => Scaffold(
+  Widget build(context) {
+
+    // Get.put()을 사용하여 클래스를 인스턴스화하여 모든 "child'에서 사용가능하게 합니다.
+    final Controller c = Get.put(Controller());
+    
+    return Scaffold(
       // count가 변경 될 때마다 Obx(()=> 를 사용하여 Text()에 업데이트합니다.
       appBar: AppBar(title: Obx(() => Text("Clicks: ${c.count}"))),
 
@@ -136,6 +138,7 @@ class Home extends StatelessWidget {
               child: Text("Go to Other"), onPressed: () => Get.to(Other()))),
       floatingActionButton:
           FloatingActionButton(child: Icon(Icons.add), onPressed: c.increment));
+  }
 }
 
 class Other extends StatelessWidget {

--- a/README.md
+++ b/README.md
@@ -123,11 +123,13 @@ class Controller extends GetxController{
 ```dart
 class Home extends StatelessWidget {
 
-  // Instantiate your class using Get.put() to make it available for all "child" routes there.
-  final Controller c = Get.put(Controller());
-
   @override
-  Widget build(context) => Scaffold(
+  Widget build(context) {
+    
+    // Instantiate your class using Get.put() to make it available for all "child" routes there.
+    final Controller c = Get.put(Controller());
+
+    return Scaffold(
       // Use Obx(()=> to update Text() whenever count is changed.
       appBar: AppBar(title: Obx(() => Text("Clicks: ${c.count}"))),
 
@@ -136,6 +138,7 @@ class Home extends StatelessWidget {
               child: Text("Go to Other"), onPressed: () => Get.to(Other()))),
       floatingActionButton:
           FloatingActionButton(child: Icon(Icons.add), onPressed: c.increment));
+  }
 }
 
 class Other extends StatelessWidget {

--- a/README.pl.md
+++ b/README.pl.md
@@ -102,11 +102,13 @@ Tworzymy View. Użyj StatelessWidget oszczędzajac przy tym RAM. Z Get nie będz
 ```dart
 class Home extends StatelessWidget {
 
-  // Instantiate your class using Get.put() to make it available for all "child" routes there.
-  final Controller c = Get.put(Controller());
-
   @override
-  Widget build(context) => Scaffold(
+  Widget build(context) {
+
+    // Instantiate your class using Get.put() to make it available for all "child" routes there.
+    final Controller c = Get.put(Controller());
+
+    return Scaffold(
       // Use Obx(()=> to update Text() whenever count is changed.
       appBar: AppBar(title: Obx(() => Text("Clicks: " + c.count.string))),
 
@@ -115,6 +117,7 @@ class Home extends StatelessWidget {
               child: Text("Go to Other"), onPressed: () => Get.to(Other()))),
       floatingActionButton:
           FloatingActionButton(child: Icon(Icons.add), onPressed: c.increment));
+  }
 }
 
 class Other extends StatelessWidget {

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -124,16 +124,23 @@ Crie sua View usando StatelessWidget, já que, usando Get, você não precisa ma
 
 ```dart
 class Home extends StatelessWidget {
-  // Instancie sua classe usando Get.put() para torná-la disponível para todas as rotas subsequentes
-  final Controller c = Get.put(Controller());
+
   @override
-  Widget build(context) => Scaffold(
-    appBar: AppBar(title: Obx(() => Text("Total de cliques: ${c.count}"))),
+  Widget build(context) { 
+
+    // Instancie sua classe usando Get.put() para torná-la disponível para todas as rotas subsequentes
+    final Controller c = Get.put(Controller());
+
+    return Scaffold(
+      // Use Obx(()=> para atualizar Text() sempre que a contagem é alterada.
+      appBar: AppBar(title: Obx(() => Text("Total de cliques: ${c.count}"))),
+
       // Troque o Navigator.push de 8 linhas por um simples Get.to(). Você não precisa do 'context'
-    body: Center(child: RaisedButton(
-      child: Text("Ir pra Outra tela"), onPressed: () => Get.to(Outra()))),
-    floatingActionButton: FloatingActionButton(child:
-     Icon(Icons.add), onPressed: c.increment));
+      body: Center(child: RaisedButton(
+              child: Text("Ir pra Outra tela"), onPressed: () => Get.to(Outra()))),
+      floatingActionButton: 
+          FloatingActionButton(child: Icon(Icons.add), onPressed: c.increment));
+  } 
 }
 
 class Outra extends StatelessWidget {

--- a/README.ru.md
+++ b/README.ru.md
@@ -118,11 +118,13 @@ class Controller extends GetxController{
 ```dart
 class Home extends StatelessWidget {
 
-  // Instantiate your class using Get.put() to make it available for all "child" routes there.
-  final Controller c = Get.put(Controller());
-
   @override
-  Widget build(context) => Scaffold(
+  Widget build(context) {
+    
+    // Instantiate your class using Get.put() to make it available for all "child" routes there.
+    final Controller c = Get.put(Controller());
+
+    return Scaffold(
       // Use Obx(()=> to update Text() whenever count is changed.
       appBar: AppBar(title: Obx(() => Text("Clicks: ${c.count}"))),
 
@@ -131,6 +133,7 @@ class Home extends StatelessWidget {
               child: Text("Go to Other"), onPressed: () => Get.to(Other()))),
       floatingActionButton:
           FloatingActionButton(child: Icon(Icons.add), onPressed: c.increment));
+  }
 }
 
 class Other extends StatelessWidget {

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -122,11 +122,13 @@ class Controller extends GetxController{
 ```dart
 class Home extends StatelessWidget {
 
-  // 使用Get.put()实例化你的类，使其对当下的所有子路由可用。
-  final Controller c = Get.put(Controller());
-
   @override
-  Widget build(context) => Scaffold(
+  Widget build(context) {
+
+    // 使用Get.put()实例化你的类，使其对当下的所有子路由可用。
+    final Controller c = Get.put(Controller());
+
+    return Scaffold(
       // 使用Obx(()=>每当改变计数时，就更新Text()。
       appBar: AppBar(title: Obx(() => Text("Clicks: ${c.count}"))),
 
@@ -135,6 +137,7 @@ class Home extends StatelessWidget {
               child: Text("Go to Other"), onPressed: () => Get.to(Other()))),
       floatingActionButton:
           FloatingActionButton(child: Icon(Icons.add), onPressed: c.increment));
+  }
 }
 
 class Other extends StatelessWidget {


### PR DESCRIPTION
- **Change to the readme sample code, in the "Counter App with GetX" section**

**Before:**
```dart
class Home extends StatelessWidget {
  final Controller c = Get.put(Controller());
  @override
  Widget build(context) => Scaffold(
      ...  
```


**After:**
```dart
class Home extends StatelessWidget {
  @override
  Widget build(context) {
    final Controller c = Get.put(Controller());
    return Scaffold(
        ...
```

- **Motivation**: Avoid issues of beginners who do not use named routes. If Get.put is placed before the build method, onInit/onReady/onClose are not called and when navigating to another route the controller is not removed from memory

- **Referência**: https://github.com/jonataslaw/getx/issues/384#issuecomment-661919495