### PR TITLE
Fix bugs in GetConnect

### DIFF
--- a/lib/get_connect/connect.dart
+++ b/lib/get_connect/connect.dart
@@ -110,7 +110,7 @@ class GetConnect extends GetConnectInterface {
     Decoder<T> decoder,
   }) {
     _checkIfDisposed();
-    return httpClient.get(
+    return httpClient.get<T>(
       url,
       headers: headers,
       contentType: contentType,
@@ -149,7 +149,7 @@ class GetConnect extends GetConnectInterface {
     Decoder<T> decoder,
   }) {
     _checkIfDisposed();
-    return httpClient.put(
+    return httpClient.put<T>(
       url,
       body: body,
       headers: headers,
@@ -170,7 +170,7 @@ class GetConnect extends GetConnectInterface {
     Decoder<T> decoder,
   }) {
     _checkIfDisposed();
-    return httpClient.request(
+    return httpClient.request<T>(
       url,
       method,
       body: body,

--- a/lib/get_connect/http/src/http.dart
+++ b/lib/get_connect/http/src/http.dart
@@ -127,13 +127,14 @@ class GetHttpClient {
 
     final uri = _createUri(url, query);
 
-    return Request(
+    return Request<T>(
       method: method,
       url: uri,
       headers: headers,
       bodyBytes: bodyStream,
       followRedirects: followRedirects,
       maxRedirects: maxRedirects,
+      decoder: decoder
     );
   }
 
@@ -168,7 +169,7 @@ class GetHttpClient {
       if (HttpStatus.unauthorized == response.statusCode &&
           _modifier.authenticator != null &&
           requestNumber <= maxAuthRetries) {
-        return _performRequest(
+        return _performRequest<T>(
           handler,
           authenticate: true,
           requestNumber: requestNumber + 1,
@@ -247,7 +248,7 @@ class GetHttpClient {
     @required Map<String, dynamic> query,
     Decoder<T> decoder,
   }) {
-    return _requestWithBody(url, contentType, body, method, query, decoder);
+    return _requestWithBody<T>(url, contentType, body, method, query, decoder);
   }
 
   Future<Request<T>> _put<T>(
@@ -257,7 +258,7 @@ class GetHttpClient {
     @required Map<String, dynamic> query,
     Decoder<T> decoder,
   }) {
-    return _requestWithBody(url, contentType, body, 'put', query, decoder);
+    return _requestWithBody<T>(url, contentType, body, 'put', query, decoder);
   }
 
   Request<T> _delete<T>(
@@ -319,8 +320,8 @@ class GetHttpClient {
     Decoder<T> decoder,
   }) async {
     try {
-      var response = await _performRequest(
-        () => _request(
+      var response = await _performRequest<T>(
+        () => _request<T>(
           url,
           method,
           contentType: contentType,
@@ -353,8 +354,8 @@ class GetHttpClient {
     Decoder<T> decoder,
   }) async {
     try {
-      var response = await _performRequest(
-        () => _put(
+      var response = await _performRequest<T>(
+        () => _put<T>(
           url,
           contentType: contentType,
           query: query,
@@ -411,7 +412,7 @@ class GetHttpClient {
     Decoder<T> decoder,
   }) async {
     try {
-      var response = await _performRequest(
+      var response = await _performRequest<T>(
         () async => _delete<T>(url, contentType, query, decoder),
         headers: headers,
       );

--- a/lib/get_connect/http/src/request/request.dart
+++ b/lib/get_connect/http/src/request/request.dart
@@ -54,7 +54,7 @@ class Request<T> {
     int maxRedirects = 4,
     FormData files,
     bool persistentConnection = true,
-    final Decoder<T> decoder,
+    Decoder<T> decoder,
   }) {
     assert(url != null);
     assert(method != null);


### PR DESCRIPTION
- Request Method without decoder parameter (http.dart)
- Remove "final" of decoder parameter (request.dart)
- Type methods for standardization