### PR TITLE
Apply the defaultEncoder to all http methods

### DIFF
--- a/lib/get_connect/http/src/http.dart
+++ b/lib/get_connect/http/src/http.dart
@@ -134,7 +134,7 @@ class GetHttpClient {
       bodyBytes: bodyStream,
       followRedirects: followRedirects,
       maxRedirects: maxRedirects,
-      decoder: decoder
+      decoder: decoder,
     );
   }
 
@@ -236,7 +236,7 @@ class GetHttpClient {
       body,
       'post',
       query,
-      decoder,
+      decoder ?? (defaultDecoder as Decoder<T>),
     );
   }
 
@@ -248,7 +248,14 @@ class GetHttpClient {
     @required Map<String, dynamic> query,
     Decoder<T> decoder,
   }) {
-    return _requestWithBody<T>(url, contentType, body, method, query, decoder);
+    return _requestWithBody<T>(
+      url,
+      contentType,
+      body,
+      method,
+      query,
+      decoder ?? (defaultDecoder as Decoder<T>),
+    );
   }
 
   Future<Request<T>> _put<T>(
@@ -258,7 +265,14 @@ class GetHttpClient {
     @required Map<String, dynamic> query,
     Decoder<T> decoder,
   }) {
-    return _requestWithBody<T>(url, contentType, body, 'put', query, decoder);
+    return _requestWithBody<T>(
+      url,
+      contentType,
+      body,
+      'put',
+      query,
+      decoder ?? (defaultDecoder as Decoder<T>),
+    );
   }
 
   Request<T> _delete<T>(
@@ -272,7 +286,11 @@ class GetHttpClient {
     final uri = _createUri(url, query);
 
     return Request<T>(
-        method: 'delete', url: uri, headers: headers, decoder: decoder);
+      method: 'delete',
+      url: uri,
+      headers: headers,
+      decoder: decoder ?? (defaultDecoder as Decoder<T>),
+    );
   }
 
   Future<Response<T>> post<T>(


### PR DESCRIPTION
In the example below, `request` was not receiving `defaultEncoder` setted in `onInit`:
```dart
Future<Response<ItemModel>> getItem() => request<ItemModel>>(url,  'get');
```
