### PR TITLE
Fix index out of range when parsing response

### DIFF
--- a/lib/get_connect/http/src/response/response.dart
+++ b/lib/get_connect/http/src/response/response.dart
@@ -227,11 +227,11 @@ class HeaderValue {
           parameters[name] = null;
           return;
         }
-        var value = parseParameterValue();
-        if (name == 'charset' && value != null) {
-          value = value.toLowerCase();
+        var val = parseParameterValue();
+        if (name == 'charset' && val != null) {
+          val = val.toLowerCase();
         }
-        parameters[name] = value;
+        parameters[name] = val;
         bump();
         if (done()) return;
         if (value[index] == valueSeparator) return;

--- a/lib/get_connect/http/src/response/response.dart
+++ b/lib/get_connect/http/src/response/response.dart
@@ -227,9 +227,9 @@ class HeaderValue {
           parameters[name] = null;
           return;
         }
-        var val = parseParameterValue();
-        if (name == 'charset' && val != null) {
-          val = val.toLowerCase();
+        var valueParameter = parseParameterValue();
+        if (name == 'charset' && valueParameter != null) {
+          valueParameter = val.toLowerCase();
         }
         parameters[name] = val;
         bump();

--- a/lib/get_connect/http/src/response/response.dart
+++ b/lib/get_connect/http/src/response/response.dart
@@ -231,7 +231,7 @@ class HeaderValue {
         if (name == 'charset' && valueParameter != null) {
           valueParameter = val.toLowerCase();
         }
-        parameters[name] = val;
+        parameters[name] = valueParameter;
         bump();
         if (done()) return;
         if (value[index] == valueSeparator) return;

--- a/lib/get_connect/http/src/response/response.dart
+++ b/lib/get_connect/http/src/response/response.dart
@@ -229,7 +229,7 @@ class HeaderValue {
         }
         var valueParameter = parseParameterValue();
         if (name == 'charset' && valueParameter != null) {
-          valueParameter = val.toLowerCase();
+          valueParameter = valueParameter .toLowerCase();
         }
         parameters[name] = valueParameter;
         bump();


### PR DESCRIPTION
The parameter value variable has the same name with the original value causes error 'index out of range' when calling value[index] in the next lines.