### PR TITLE
Demo test of invalid description of offUntil and offNamedUntil predicate

### DIFF
--- a/test/navigation/get_main_test.dart
+++ b/test/navigation/get_main_test.dart
@@ -209,6 +209,12 @@ void main() {
 
     await tester.pumpAndSettle();
 
+    expect(find.byType(ThirdScreen), findsOneWidget);
+
+    Get.back();
+
+    await tester.pumpAndSettle();
+
     expect(find.byType(FirstScreen), findsOneWidget);
   });
 
@@ -240,7 +246,13 @@ void main() {
 
     expect(find.byType(SecondScreen), findsOneWidget);
 
-    Get.offNamedUntil('/third', ModalRoute.withName('/first'));
+    Get.offNamedUntil('/third', (route) => Get.currentRoute == '/FirstScreen');
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ThirdScreen), findsOneWidget);
+
+    Get.back();
 
     await tester.pumpAndSettle();
 

--- a/test/navigation/get_main_test.dart
+++ b/test/navigation/get_main_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
+
 import 'utils/wrapper.dart';
 
 class SizeTransitions extends CustomTransition {
@@ -195,19 +196,20 @@ void main() {
     );
 
     Get.to(FirstScreen());
-
-    await tester.pumpAndSettle();
-
-    expect(find.byType(FirstScreen), findsOneWidget);
-
-    Get.offUntil(
-      MaterialPageRoute(builder: (context) => SecondScreen()),
-      ModalRoute.withName('/'),
-    );
+    Get.to(SecondScreen());
 
     await tester.pumpAndSettle();
 
     expect(find.byType(SecondScreen), findsOneWidget);
+
+    Get.offUntil(
+      MaterialPageRoute(builder: (context) => ThirdScreen()),
+      (route) => Get.currentRoute == '/FirstScreen',
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FirstScreen), findsOneWidget);
   });
 
   testWidgets("Get.offNamedUntil smoke test", (tester) async {
@@ -232,12 +234,13 @@ void main() {
     );
 
     Get.toNamed('/first');
+    Get.toNamed('/second');
 
     await tester.pumpAndSettle();
 
-    expect(find.byType(FirstScreen), findsOneWidget);
+    expect(find.byType(SecondScreen), findsOneWidget);
 
-    Get.offNamedUntil('/first', ModalRoute.withName('/'));
+    Get.offNamedUntil('/third', ModalRoute.withName('/first'));
 
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
This PR created to demonstrate that currently suggested description of predicate parameter in `offUntil` and `offNamedUntil` comments leads to wrong navigation stack. 

The quote from invalid comments:
```
/// [predicate] can be used like this:
/// `Get.until((route) => Get.currentRoute == '/home')`so when you get to home page,
```
Also, this PR appeared to support another PR which fixes mentioned issue.

Can be closed after checking.

