### PR TITLE
Update offUntil and offNamedUntil docs

### DIFF
--- a/lib/get_navigation/src/extension_navigation.dart
+++ b/lib/get_navigation/src/extension_navigation.dart
@@ -2,6 +2,7 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+
 import '../../get_core/get_core.dart';
 import '../../get_instance/src/bindings_interface.dart';
 import '../../get_utils/get_utils.dart';
@@ -592,11 +593,11 @@ extension GetNavigation on GetInterface {
   ///
   /// Obs: unlike other get methods, this one you need to send a function
   /// that returns the widget to the page argument, like this:
-  /// Get.offUntil( () => HomePage() )
+  /// Get.offUntil(GetPageRoute(page: () => HomePage()), predicate)
   ///
   /// [predicate] can be used like this:
-  /// `Get.until((route) => Get.currentRoute == '/home')`so when you get to home page,
-  ///
+  /// `Get.offUntil(page, (route) => (route as GetPageRoute).routeName == '/home')`
+  /// to pop routes in stack until home,
   /// or also like this:
   /// `Get.until((route) => !Get.isDialogOpen())`, to make sure the dialog
   /// is closed
@@ -617,12 +618,13 @@ extension GetNavigation on GetInterface {
   /// as explained in documentation
   ///
   /// [predicate] can be used like this:
-  /// `Get.until((route) => Get.currentRoute == '/home')`so when you get to home page,
-  /// or also like
-  /// `Get.until((route) => !Get.isDialogOpen())`, to make sure the dialog
-  /// is closed
+  /// `Get.offNamedUntil(page, (route) => (route as GetPageRoute).routeName == '/home')`
+  /// to pop routes in stack until home,
+  /// or like this:
+  /// `Get.offNamedUntil((route) => !Get.isDialogOpen())`,
+  /// to make sure the dialog is closed
   ///
-  /// Note: Always put a slash on the route ('/page1'), to avoid unnexpected errors
+  /// Note: Always put a slash on the route name ('/page1'), to avoid unexpected errors
   Future<T> offNamedUntil<T>(
     String page,
     RoutePredicate predicate, {

--- a/lib/get_navigation/src/extension_navigation.dart
+++ b/lib/get_navigation/src/extension_navigation.dart
@@ -618,7 +618,7 @@ extension GetNavigation on GetInterface {
   /// as explained in documentation
   ///
   /// [predicate] can be used like this:
-  /// `Get.offNamedUntil(page, (route) => (route as GetPageRoute).routeName == '/home')`
+  /// `Get.offNamedUntil(page, ModalRoute.withName('/home'))`
   /// to pop routes in stack until home,
   /// or like this:
   /// `Get.offNamedUntil((route) => !Get.isDialogOpen())`,

--- a/test/navigation/get_main_test.dart
+++ b/test/navigation/get_main_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
+
 import 'utils/wrapper.dart';
 
 class SizeTransitions extends CustomTransition {
@@ -198,16 +199,21 @@ void main() {
 
     await tester.pumpAndSettle();
 
-    expect(find.byType(FirstScreen), findsOneWidget);
-
-    Get.offUntil(
-      MaterialPageRoute(builder: (context) => SecondScreen()),
-      ModalRoute.withName('/'),
-    );
+    Get.to(SecondScreen());
 
     await tester.pumpAndSettle();
 
-    expect(find.byType(SecondScreen), findsOneWidget);
+    Get.offUntil(GetPageRoute(page: () => ThirdScreen()),
+        (route) => (route as GetPageRoute).routeName == '/FirstScreen');
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ThirdScreen), findsOneWidget);
+    Get.back();
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FirstScreen), findsOneWidget);
   });
 
   testWidgets("Get.offNamedUntil smoke test", (tester) async {
@@ -232,12 +238,19 @@ void main() {
     );
 
     Get.toNamed('/first');
+    Get.toNamed('/second');
 
     await tester.pumpAndSettle();
 
-    expect(find.byType(FirstScreen), findsOneWidget);
+    expect(find.byType(SecondScreen), findsOneWidget);
 
-    Get.offNamedUntil('/first', ModalRoute.withName('/'));
+    Get.offNamedUntil('/third', ModalRoute.withName('/first'));
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ThirdScreen), findsOneWidget);
+
+    Get.back();
 
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
This PR changes docs for `offUntil()` and `offNamedUntil()` navigation extensions, because current description for the `predicate` parameter is invalid and leads to wrong navigation stack if used as suggested. I got caught by such invalid description on one project, so fixing to prevent others from incorrect usage.

To confirm that current description is wrong I updated tests to use the predicate in suggested way and opened #860 

After this PR gets merged I will create another PR to update navigation extensions tests to check exactly one behavior in one tests, because with this PR I test multiple conditions in one test.