### PR TITLE
Refactoring for navigation extensions tests

### DIFF
--- a/test/navigation/get_main_test.dart
+++ b/test/navigation/get_main_test.dart
@@ -20,9 +20,9 @@ void main() {
   testWidgets("Get.toNamed navigates to provided named route", (tester) async {
     await tester.pumpWidget(
       GetMaterialApp(
-        initialRoute: '/',
+        initialRoute: '/first',
         getPages: [
-          GetPage(page: () => FirstScreen(), name: '/'),
+          GetPage(page: () => FirstScreen(), name: '/first'),
           GetPage(page: () => SecondScreen(), name: '/second'),
           GetPage(page: () => ThirdScreen(), name: '/third')
         ],
@@ -38,10 +38,9 @@ void main() {
 
   testWidgets("Get.off navigates to provided route", (tester) async {
     await tester.pumpWidget(
-      Wrapper(child: Container()),
+      Wrapper(child: FirstScreen()),
     );
 
-    Get.to(FirstScreen());
     Get.off(SecondScreen());
 
     await tester.pumpAndSettle();
@@ -51,10 +50,9 @@ void main() {
 
   testWidgets("Get.off removes current route", (tester) async {
     await tester.pumpWidget(
-      Wrapper(child: Container()),
+      Wrapper(child: FirstScreen()),
     );
 
-    Get.to(FirstScreen());
     Get.off(SecondScreen());
     Get.back();
 
@@ -66,9 +64,8 @@ void main() {
   testWidgets("Get.offNamed navigates to provided named route", (tester) async {
     await tester.pumpWidget(
       GetMaterialApp(
-        initialRoute: '/',
+        initialRoute: '/first',
         getPages: [
-          GetPage(name: '/', page: () => Container()),
           GetPage(name: '/first', page: () => FirstScreen()),
           GetPage(name: '/second', page: () => SecondScreen()),
           GetPage(name: '/third', page: () => ThirdScreen()),
@@ -76,19 +73,18 @@ void main() {
       ),
     );
 
-    Get.offNamed('/first');
+    Get.offNamed('/second');
 
     await tester.pumpAndSettle();
 
-    expect(find.byType(FirstScreen), findsOneWidget);
+    expect(find.byType(SecondScreen), findsOneWidget);
   });
 
   testWidgets("Get.offNamed removes current route", (tester) async {
     await tester.pumpWidget(
       GetMaterialApp(
-        initialRoute: '/',
+        initialRoute: '/first',
         getPages: [
-          GetPage(name: '/', page: () => Container()),
           GetPage(name: '/first', page: () => FirstScreen()),
           GetPage(name: '/second', page: () => SecondScreen()),
           GetPage(name: '/third', page: () => ThirdScreen()),
@@ -96,7 +92,6 @@ void main() {
       ),
     );
 
-    Get.toNamed('/first');
     Get.offNamed('/second');
     Get.back();
 
@@ -108,9 +103,8 @@ void main() {
   testWidgets("Get.offNamed removes only current route", (tester) async {
     await tester.pumpWidget(
       GetMaterialApp(
-        initialRoute: '/',
+        initialRoute: '/first',
         getPages: [
-          GetPage(name: '/', page: () => Container()),
           GetPage(name: '/first', page: () => FirstScreen()),
           GetPage(name: '/second', page: () => SecondScreen()),
           GetPage(name: '/third', page: () => ThirdScreen()),
@@ -118,33 +112,32 @@ void main() {
       ),
     );
 
-    Get.toNamed('/first');
-    Get.offNamed('/second');
+    Get.toNamed('/second');
+    Get.offNamed('/third');
     Get.back();
-
-    await tester.pumpAndSettle();
-
-    expect(find.byType(Container), findsOneWidget);
-  });
-
-  testWidgets("Get.offAll navigates to provided route", (tester) async {
-    await tester.pumpWidget(
-      Wrapper(child: Container()),
-    );
-
-    Get.offAll(FirstScreen());
 
     await tester.pumpAndSettle();
 
     expect(find.byType(FirstScreen), findsOneWidget);
   });
 
-  testWidgets("Get.offAll removes all previous routes", (tester) async {
+  testWidgets("Get.offAll navigates to provided route", (tester) async {
     await tester.pumpWidget(
-      Wrapper(child: Container()),
+      Wrapper(child: FirstScreen()),
     );
 
-    Get.to(FirstScreen());
+    Get.offAll(SecondScreen());
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SecondScreen), findsOneWidget);
+  });
+
+  testWidgets("Get.offAll removes all previous routes", (tester) async {
+    await tester.pumpWidget(
+      Wrapper(child: FirstScreen()),
+    );
+
     Get.to(SecondScreen());
     Get.offAll(ThirdScreen());
     Get.back();
@@ -207,24 +200,17 @@ void main() {
     expect(find.byType(FirstScreen), findsNothing);
   });
 
-  testWidgets("Get.offAndToNamed smoke test", (tester) async {
+  testWidgets("Get.offAndToNamed navigates to provided route", (tester) async {
     await tester.pumpWidget(
       WrapperNamed(
-        initialRoute: '/',
+        initialRoute: '/first',
         namedRoutes: [
-          GetPage(page: () => Container(), name: '/'),
           GetPage(page: () => FirstScreen(), name: '/first'),
           GetPage(page: () => SecondScreen(), name: '/second'),
-          GetPage(page: () => ThirdScreen(), name: '/third'),
+          GetPage(page: () => ThirdScreen(), name: '/third')
         ],
       ),
     );
-
-    Get.toNamed('/first');
-
-    await tester.pumpAndSettle();
-
-    expect(find.byType(FirstScreen), findsOneWidget);
 
     Get.offAndToNamed('/second');
 
@@ -233,20 +219,32 @@ void main() {
     expect(find.byType(SecondScreen), findsOneWidget);
   });
 
-  testWidgets("Get.offUntil smoke test", (tester) async {
+  testWidgets("Get.offAndToNamed removes previous route", (tester) async {
     await tester.pumpWidget(
-      Wrapper(
-        child: Container(),
+      WrapperNamed(
+        initialRoute: '/first',
+        namedRoutes: [
+          GetPage(page: () => FirstScreen(), name: '/first'),
+          GetPage(page: () => SecondScreen(), name: '/second'),
+          GetPage(page: () => ThirdScreen(), name: '/third')
+        ],
       ),
     );
 
-    Get.to(FirstScreen());
+    Get.offAndToNamed('/second');
+    Get.back();
 
     await tester.pumpAndSettle();
 
-    Get.to(SecondScreen());
+    expect(find.byType(FirstScreen), findsNothing);
+  });
 
-    await tester.pumpAndSettle();
+  testWidgets("Get.offUntil navigates to provided route", (tester) async {
+    await tester.pumpWidget(
+      Wrapper(
+        child: FirstScreen(),
+      ),
+    );
 
     Get.offUntil(GetPageRoute(page: () => ThirdScreen()),
         (route) => (route as GetPageRoute).routeName == '/FirstScreen');
@@ -254,6 +252,41 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(ThirdScreen), findsOneWidget);
+  });
+
+  testWidgets(
+      "Get.offUntil removes previous routes if they don't match predicate",
+      (tester) async {
+    await tester.pumpWidget(
+      Wrapper(
+        child: Container(),
+      ),
+    );
+
+    Get.to(FirstScreen());
+    Get.to(SecondScreen());
+    Get.offUntil(GetPageRoute(page: () => ThirdScreen()),
+        (route) => (route as GetPageRoute).routeName == '/FirstScreen');
+    Get.back();
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SecondScreen), findsNothing);
+  });
+
+  testWidgets(
+      "Get.offUntil leaves previous routes that match provided predicate",
+      (tester) async {
+    await tester.pumpWidget(
+      Wrapper(
+        child: Container(),
+      ),
+    );
+
+    Get.to(FirstScreen());
+    Get.to(SecondScreen());
+    Get.offUntil(GetPageRoute(page: () => ThirdScreen()),
+        (route) => (route as GetPageRoute).routeName == '/FirstScreen');
     Get.back();
 
     await tester.pumpAndSettle();

--- a/test/navigation/get_main_test.dart
+++ b/test/navigation/get_main_test.dart
@@ -4,53 +4,27 @@ import 'package:get/get.dart';
 
 import 'utils/wrapper.dart';
 
-class SizeTransitions extends CustomTransition {
-  @override
-  Widget buildTransition(
-      BuildContext context,
-      Curve curve,
-      Alignment alignment,
-      Animation<double> animation,
-      Animation<double> secondaryAnimation,
-      Widget child) {
-    return Align(
-      alignment: Alignment.center,
-      child: SizeTransition(
-        sizeFactor: CurvedAnimation(
-          parent: animation,
-          curve: curve,
-        ),
-        child: child,
-      ),
-    );
-  }
-}
-
 void main() {
-  testWidgets("Get.to smoke test", (tester) async {
+  testWidgets("Get.to navigates to provided route", (tester) async {
     await tester.pumpWidget(
       Wrapper(child: Container()),
     );
 
-    Get.to(SecondScreen());
-
-    await tester.pump(Duration.zero);
+    Get.to(FirstScreen());
 
     await tester.pumpAndSettle();
 
-    expect(find.byType(SecondScreen), findsOneWidget);
+    expect(find.byType(FirstScreen), findsOneWidget);
   });
-  testWidgets("Get.toNamed smoke test", (tester) async {
+
+  testWidgets("Get.toNamed navigates to provided named route", (tester) async {
     await tester.pumpWidget(
       GetMaterialApp(
         initialRoute: '/',
         getPages: [
-          GetPage(
-              page: () => FirstScreen(),
-              name: '/',
-              customTransition: SizeTransitions()),
+          GetPage(page: () => FirstScreen(), name: '/'),
           GetPage(page: () => SecondScreen(), name: '/second'),
-          GetPage(page: () => ThirdScreen(), name: '/third'),
+          GetPage(page: () => ThirdScreen(), name: '/third')
         ],
       ),
     );
@@ -62,17 +36,12 @@ void main() {
     expect(find.byType(SecondScreen), findsOneWidget);
   });
 
-  testWidgets("Get.off smoke test", (tester) async {
+  testWidgets("Get.off navigates to provided route", (tester) async {
     await tester.pumpWidget(
       Wrapper(child: Container()),
     );
 
     Get.to(FirstScreen());
-
-    await tester.pumpAndSettle();
-
-    expect(find.byType(FirstScreen), findsOneWidget);
-
     Get.off(SecondScreen());
 
     await tester.pumpAndSettle();
@@ -80,7 +49,41 @@ void main() {
     expect(find.byType(SecondScreen), findsOneWidget);
   });
 
-  testWidgets("Get.offNamed smoke test", (tester) async {
+  testWidgets("Get.off removes current route", (tester) async {
+    await tester.pumpWidget(
+      Wrapper(child: Container()),
+    );
+
+    Get.to(FirstScreen());
+    Get.off(SecondScreen());
+    Get.back();
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FirstScreen), findsNothing);
+  });
+
+  testWidgets("Get.offNamed navigates to provided named route", (tester) async {
+    await tester.pumpWidget(
+      GetMaterialApp(
+        initialRoute: '/',
+        getPages: [
+          GetPage(name: '/', page: () => Container()),
+          GetPage(name: '/first', page: () => FirstScreen()),
+          GetPage(name: '/second', page: () => SecondScreen()),
+          GetPage(name: '/third', page: () => ThirdScreen()),
+        ],
+      ),
+    );
+
+    Get.offNamed('/first');
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FirstScreen), findsOneWidget);
+  });
+
+  testWidgets("Get.offNamed removes current route", (tester) async {
     await tester.pumpWidget(
       GetMaterialApp(
         initialRoute: '/',
@@ -94,72 +97,114 @@ void main() {
     );
 
     Get.toNamed('/first');
-
-    await tester.pumpAndSettle();
-
-    expect(find.byType(FirstScreen), findsOneWidget);
-
     Get.offNamed('/second');
+    Get.back();
 
     await tester.pumpAndSettle();
 
-    expect(find.byType(SecondScreen), findsOneWidget);
+    expect(find.byType(FirstScreen), findsNothing);
   });
 
-  testWidgets("Get.offAll smoke test", (tester) async {
+  testWidgets("Get.offNamed removes only current route", (tester) async {
     await tester.pumpWidget(
-      Wrapper(child: Container()),
-    );
-
-    Get.to(FirstScreen());
-
-    await tester.pumpAndSettle();
-
-    expect(find.byType(FirstScreen), findsOneWidget);
-
-    Get.to(SecondScreen());
-
-    await tester.pumpAndSettle();
-
-    expect(find.byType(SecondScreen), findsOneWidget);
-
-    Get.offAll(ThirdScreen());
-
-    await tester.pumpAndSettle();
-
-    expect(find.byType(ThirdScreen), findsOneWidget);
-  });
-
-  testWidgets("Get.offAllNamed smoke test", (tester) async {
-    await tester.pumpWidget(
-      WrapperNamed(
+      GetMaterialApp(
         initialRoute: '/',
-        namedRoutes: [
-          GetPage(page: () => Container(), name: '/'),
-          GetPage(page: () => FirstScreen(), name: '/first'),
-          GetPage(page: () => SecondScreen(), name: '/second'),
-          GetPage(page: () => ThirdScreen(), name: '/third'),
+        getPages: [
+          GetPage(name: '/', page: () => Container()),
+          GetPage(name: '/first', page: () => FirstScreen()),
+          GetPage(name: '/second', page: () => SecondScreen()),
+          GetPage(name: '/third', page: () => ThirdScreen()),
         ],
       ),
     );
 
     Get.toNamed('/first');
+    Get.offNamed('/second');
+    Get.back();
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Container), findsOneWidget);
+  });
+
+  testWidgets("Get.offAll navigates to provided route", (tester) async {
+    await tester.pumpWidget(
+      Wrapper(child: Container()),
+    );
+
+    Get.offAll(FirstScreen());
 
     await tester.pumpAndSettle();
 
     expect(find.byType(FirstScreen), findsOneWidget);
+  });
+
+  testWidgets("Get.offAll removes all previous routes", (tester) async {
+    await tester.pumpWidget(
+      Wrapper(child: Container()),
+    );
+
+    Get.to(FirstScreen());
+    Get.to(SecondScreen());
+    Get.offAll(ThirdScreen());
+    Get.back();
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SecondScreen), findsNothing);
+
+    Get.back();
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FirstScreen), findsNothing);
+  });
+
+  testWidgets("Get.offAllNamed navigates to provided named route",
+      (tester) async {
+    await tester.pumpWidget(
+      WrapperNamed(
+        initialRoute: '/first',
+        namedRoutes: [
+          GetPage(page: () => FirstScreen(), name: '/first'),
+          GetPage(page: () => SecondScreen(), name: '/second'),
+          GetPage(page: () => ThirdScreen(), name: '/third')
+        ],
+      ),
+    );
 
     Get.toNamed('/second');
 
     await tester.pumpAndSettle();
 
     expect(find.byType(SecondScreen), findsOneWidget);
+  });
 
+  testWidgets("Get.offAllNamed removes all previous routes", (tester) async {
+    await tester.pumpWidget(
+      WrapperNamed(
+        initialRoute: '/first',
+        namedRoutes: [
+          GetPage(page: () => FirstScreen(), name: '/first'),
+          GetPage(page: () => SecondScreen(), name: '/second'),
+          GetPage(page: () => ThirdScreen(), name: '/third')
+        ],
+      ),
+    );
+
+    Get.toNamed('/second');
     Get.offAllNamed('/third');
+    Get.back();
 
     await tester.pumpAndSettle();
 
-    expect(find.byType(ThirdScreen), findsOneWidget);
+    expect(find.byType(SecondScreen), findsNothing);
+
+    Get.back();
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FirstScreen), findsNothing);
   });
 
   testWidgets("Get.offAndToNamed smoke test", (tester) async {

--- a/test/navigation/get_main_test.dart
+++ b/test/navigation/get_main_test.dart
@@ -335,27 +335,32 @@ void main() {
     expect(find.byType(FirstScreen), findsOneWidget);
   });
 
-  testWidgets("Get.back smoke test", (tester) async {
+  testWidgets("Get.back navigates back", (tester) async {
     await tester.pumpWidget(
-      Wrapper(child: Container()),
+      Wrapper(child: FirstScreen()),
     );
 
-    Get.to(FirstScreen());
-
-    await tester.pumpAndSettle();
-
-    expect(find.byType(FirstScreen), findsOneWidget);
-
     Get.to(SecondScreen());
-
-    await tester.pumpAndSettle();
-
-    expect(find.byType(SecondScreen), findsOneWidget);
-
     Get.back();
 
     await tester.pumpAndSettle();
 
+    expect(find.byType(FirstScreen), findsOneWidget);
+  });
+
+  testWidgets("Get.back closeOverlays closes both snackbar and current route",
+      (tester) async {
+    await tester.pumpWidget(
+      Wrapper(child: FirstScreen()),
+    );
+
+    Get.to(SecondScreen());
+    Get.snackbar('title', "message");
+    Get.back(closeOverlays: true);
+
+    await tester.pumpAndSettle();
+
+    expect(Get.isSnackbarOpen, false);
     expect(find.byType(FirstScreen), findsOneWidget);
   });
 

--- a/test/navigation/get_main_test.dart
+++ b/test/navigation/get_main_test.dart
@@ -214,7 +214,9 @@ void main() {
   });
 
   testWidgets("Get.offUntil navigates to provided route", (tester) async {
-    await tester.pumpWidget(Wrapper(child: FirstScreen()));
+    await tester.pumpWidget(Wrapper(child: Container()));
+
+    Get.to(FirstScreen());
 
     Get.offUntil(GetPageRoute(page: () => ThirdScreen()),
         (route) => (route as GetPageRoute).routeName == '/FirstScreen');

--- a/test/navigation/get_main_test.dart
+++ b/test/navigation/get_main_test.dart
@@ -6,9 +6,7 @@ import 'utils/wrapper.dart';
 
 void main() {
   testWidgets("Get.to navigates to provided route", (tester) async {
-    await tester.pumpWidget(
-      Wrapper(child: Container()),
-    );
+    await tester.pumpWidget(Wrapper(child: Container()));
 
     Get.to(FirstScreen());
 
@@ -18,16 +16,14 @@ void main() {
   });
 
   testWidgets("Get.toNamed navigates to provided named route", (tester) async {
-    await tester.pumpWidget(
-      GetMaterialApp(
-        initialRoute: '/first',
-        getPages: [
-          GetPage(page: () => FirstScreen(), name: '/first'),
-          GetPage(page: () => SecondScreen(), name: '/second'),
-          GetPage(page: () => ThirdScreen(), name: '/third')
-        ],
-      ),
-    );
+    await tester.pumpWidget(GetMaterialApp(
+      initialRoute: '/first',
+      getPages: [
+        GetPage(page: () => FirstScreen(), name: '/first'),
+        GetPage(page: () => SecondScreen(), name: '/second'),
+        GetPage(page: () => ThirdScreen(), name: '/third')
+      ],
+    ));
 
     Get.toNamed('/second');
 
@@ -37,9 +33,7 @@ void main() {
   });
 
   testWidgets("Get.off navigates to provided route", (tester) async {
-    await tester.pumpWidget(
-      Wrapper(child: FirstScreen()),
-    );
+    await tester.pumpWidget(Wrapper(child: FirstScreen()));
 
     Get.off(SecondScreen());
 
@@ -49,9 +43,7 @@ void main() {
   });
 
   testWidgets("Get.off removes current route", (tester) async {
-    await tester.pumpWidget(
-      Wrapper(child: FirstScreen()),
-    );
+    await tester.pumpWidget(Wrapper(child: FirstScreen()));
 
     Get.off(SecondScreen());
     Get.back();
@@ -62,16 +54,14 @@ void main() {
   });
 
   testWidgets("Get.offNamed navigates to provided named route", (tester) async {
-    await tester.pumpWidget(
-      GetMaterialApp(
-        initialRoute: '/first',
-        getPages: [
-          GetPage(name: '/first', page: () => FirstScreen()),
-          GetPage(name: '/second', page: () => SecondScreen()),
-          GetPage(name: '/third', page: () => ThirdScreen()),
-        ],
-      ),
-    );
+    await tester.pumpWidget(GetMaterialApp(
+      initialRoute: '/first',
+      getPages: [
+        GetPage(name: '/first', page: () => FirstScreen()),
+        GetPage(name: '/second', page: () => SecondScreen()),
+        GetPage(name: '/third', page: () => ThirdScreen()),
+      ],
+    ));
 
     Get.offNamed('/second');
 
@@ -81,16 +71,14 @@ void main() {
   });
 
   testWidgets("Get.offNamed removes current route", (tester) async {
-    await tester.pumpWidget(
-      GetMaterialApp(
-        initialRoute: '/first',
-        getPages: [
-          GetPage(name: '/first', page: () => FirstScreen()),
-          GetPage(name: '/second', page: () => SecondScreen()),
-          GetPage(name: '/third', page: () => ThirdScreen()),
-        ],
-      ),
-    );
+    await tester.pumpWidget(GetMaterialApp(
+      initialRoute: '/first',
+      getPages: [
+        GetPage(name: '/first', page: () => FirstScreen()),
+        GetPage(name: '/second', page: () => SecondScreen()),
+        GetPage(name: '/third', page: () => ThirdScreen()),
+      ],
+    ));
 
     Get.offNamed('/second');
     Get.back();
@@ -101,16 +89,14 @@ void main() {
   });
 
   testWidgets("Get.offNamed removes only current route", (tester) async {
-    await tester.pumpWidget(
-      GetMaterialApp(
-        initialRoute: '/first',
-        getPages: [
-          GetPage(name: '/first', page: () => FirstScreen()),
-          GetPage(name: '/second', page: () => SecondScreen()),
-          GetPage(name: '/third', page: () => ThirdScreen()),
-        ],
-      ),
-    );
+    await tester.pumpWidget(GetMaterialApp(
+      initialRoute: '/first',
+      getPages: [
+        GetPage(name: '/first', page: () => FirstScreen()),
+        GetPage(name: '/second', page: () => SecondScreen()),
+        GetPage(name: '/third', page: () => ThirdScreen()),
+      ],
+    ));
 
     Get.toNamed('/second');
     Get.offNamed('/third');
@@ -122,9 +108,7 @@ void main() {
   });
 
   testWidgets("Get.offAll navigates to provided route", (tester) async {
-    await tester.pumpWidget(
-      Wrapper(child: FirstScreen()),
-    );
+    await tester.pumpWidget(Wrapper(child: FirstScreen()));
 
     Get.offAll(SecondScreen());
 
@@ -134,9 +118,7 @@ void main() {
   });
 
   testWidgets("Get.offAll removes all previous routes", (tester) async {
-    await tester.pumpWidget(
-      Wrapper(child: FirstScreen()),
-    );
+    await tester.pumpWidget(Wrapper(child: FirstScreen()));
 
     Get.to(SecondScreen());
     Get.offAll(ThirdScreen());
@@ -155,16 +137,14 @@ void main() {
 
   testWidgets("Get.offAllNamed navigates to provided named route",
       (tester) async {
-    await tester.pumpWidget(
-      WrapperNamed(
-        initialRoute: '/first',
-        namedRoutes: [
-          GetPage(page: () => FirstScreen(), name: '/first'),
-          GetPage(page: () => SecondScreen(), name: '/second'),
-          GetPage(page: () => ThirdScreen(), name: '/third')
-        ],
-      ),
-    );
+    await tester.pumpWidget(WrapperNamed(
+      initialRoute: '/first',
+      namedRoutes: [
+        GetPage(page: () => FirstScreen(), name: '/first'),
+        GetPage(page: () => SecondScreen(), name: '/second'),
+        GetPage(page: () => ThirdScreen(), name: '/third')
+      ],
+    ));
 
     Get.toNamed('/second');
 
@@ -174,16 +154,14 @@ void main() {
   });
 
   testWidgets("Get.offAllNamed removes all previous routes", (tester) async {
-    await tester.pumpWidget(
-      WrapperNamed(
-        initialRoute: '/first',
-        namedRoutes: [
-          GetPage(page: () => FirstScreen(), name: '/first'),
-          GetPage(page: () => SecondScreen(), name: '/second'),
-          GetPage(page: () => ThirdScreen(), name: '/third')
-        ],
-      ),
-    );
+    await tester.pumpWidget(WrapperNamed(
+      initialRoute: '/first',
+      namedRoutes: [
+        GetPage(page: () => FirstScreen(), name: '/first'),
+        GetPage(page: () => SecondScreen(), name: '/second'),
+        GetPage(page: () => ThirdScreen(), name: '/third')
+      ],
+    ));
 
     Get.toNamed('/second');
     Get.offAllNamed('/third');
@@ -201,16 +179,14 @@ void main() {
   });
 
   testWidgets("Get.offAndToNamed navigates to provided route", (tester) async {
-    await tester.pumpWidget(
-      WrapperNamed(
-        initialRoute: '/first',
-        namedRoutes: [
-          GetPage(page: () => FirstScreen(), name: '/first'),
-          GetPage(page: () => SecondScreen(), name: '/second'),
-          GetPage(page: () => ThirdScreen(), name: '/third')
-        ],
-      ),
-    );
+    await tester.pumpWidget(WrapperNamed(
+      initialRoute: '/first',
+      namedRoutes: [
+        GetPage(page: () => FirstScreen(), name: '/first'),
+        GetPage(page: () => SecondScreen(), name: '/second'),
+        GetPage(page: () => ThirdScreen(), name: '/third')
+      ],
+    ));
 
     Get.offAndToNamed('/second');
 
@@ -220,16 +196,14 @@ void main() {
   });
 
   testWidgets("Get.offAndToNamed removes previous route", (tester) async {
-    await tester.pumpWidget(
-      WrapperNamed(
-        initialRoute: '/first',
-        namedRoutes: [
-          GetPage(page: () => FirstScreen(), name: '/first'),
-          GetPage(page: () => SecondScreen(), name: '/second'),
-          GetPage(page: () => ThirdScreen(), name: '/third')
-        ],
-      ),
-    );
+    await tester.pumpWidget(WrapperNamed(
+      initialRoute: '/first',
+      namedRoutes: [
+        GetPage(page: () => FirstScreen(), name: '/first'),
+        GetPage(page: () => SecondScreen(), name: '/second'),
+        GetPage(page: () => ThirdScreen(), name: '/third')
+      ],
+    ));
 
     Get.offAndToNamed('/second');
     Get.back();
@@ -240,11 +214,7 @@ void main() {
   });
 
   testWidgets("Get.offUntil navigates to provided route", (tester) async {
-    await tester.pumpWidget(
-      Wrapper(
-        child: FirstScreen(),
-      ),
-    );
+    await tester.pumpWidget(Wrapper(child: FirstScreen()));
 
     Get.offUntil(GetPageRoute(page: () => ThirdScreen()),
         (route) => (route as GetPageRoute).routeName == '/FirstScreen');
@@ -257,13 +227,8 @@ void main() {
   testWidgets(
       "Get.offUntil removes previous routes if they don't match predicate",
       (tester) async {
-    await tester.pumpWidget(
-      Wrapper(
-        child: Container(),
-      ),
-    );
+    await tester.pumpWidget(Wrapper(child: FirstScreen()));
 
-    Get.to(FirstScreen());
     Get.to(SecondScreen());
     Get.offUntil(GetPageRoute(page: () => ThirdScreen()),
         (route) => (route as GetPageRoute).routeName == '/FirstScreen');
@@ -277,11 +242,7 @@ void main() {
   testWidgets(
       "Get.offUntil leaves previous routes that match provided predicate",
       (tester) async {
-    await tester.pumpWidget(
-      Wrapper(
-        child: Container(),
-      ),
-    );
+    await tester.pumpWidget(Wrapper(child: Container()));
 
     Get.to(FirstScreen());
     Get.to(SecondScreen());
@@ -294,40 +255,57 @@ void main() {
     expect(find.byType(FirstScreen), findsOneWidget);
   });
 
-  testWidgets("Get.offNamedUntil smoke test", (tester) async {
-    await tester.pumpWidget(
-      WrapperNamed(
-        initialRoute: '/',
-        namedRoutes: [
-          GetPage(
-              page: () => Container(),
-              name: '/',
-              popGesture: true,
-              transition: Transition.cupertino),
-          GetPage(
-              page: () => FirstScreen(),
-              name: '/first',
-              transition: Transition.size),
-          GetPage(
-              page: () => SecondScreen(), name: '/second', transition: null),
-          GetPage(page: () => ThirdScreen(), name: '/third'),
-        ],
-      ),
-    );
+  testWidgets("Get.offNamedUntil navigates to provided route", (tester) async {
+    await tester.pumpWidget(WrapperNamed(
+      initialRoute: '/first',
+      namedRoutes: [
+        GetPage(page: () => FirstScreen(), name: '/first'),
+        GetPage(page: () => SecondScreen(), name: '/second'),
+        GetPage(page: () => ThirdScreen(), name: '/third')
+      ],
+    ));
 
-    Get.toNamed('/first');
-    Get.toNamed('/second');
+    Get.offNamedUntil('/second', ModalRoute.withName('/first'));
 
     await tester.pumpAndSettle();
 
     expect(find.byType(SecondScreen), findsOneWidget);
+  });
 
+  testWidgets(
+      "Get.offNamedUntil removes previous routes if they don't match predicate",
+      (tester) async {
+    await tester.pumpWidget(WrapperNamed(
+      initialRoute: '/first',
+      namedRoutes: [
+        GetPage(page: () => FirstScreen(), name: '/first'),
+        GetPage(page: () => SecondScreen(), name: '/second'),
+        GetPage(page: () => ThirdScreen(), name: '/third')
+      ],
+    ));
+
+    Get.toNamed('/second');
     Get.offNamedUntil('/third', ModalRoute.withName('/first'));
 
     await tester.pumpAndSettle();
 
-    expect(find.byType(ThirdScreen), findsOneWidget);
+    expect(find.byType(SecondScreen), findsNothing);
+  });
 
+  testWidgets(
+      "Get.offNamedUntil leaves previous routes that match provided predicate",
+      (tester) async {
+    await tester.pumpWidget(WrapperNamed(
+      initialRoute: '/first',
+      namedRoutes: [
+        GetPage(page: () => FirstScreen(), name: '/first'),
+        GetPage(page: () => SecondScreen(), name: '/second'),
+        GetPage(page: () => ThirdScreen(), name: '/third'),
+      ],
+    ));
+
+    Get.toNamed('/second');
+    Get.offNamedUntil('/third', ModalRoute.withName('/first'));
     Get.back();
 
     await tester.pumpAndSettle();
@@ -348,11 +326,10 @@ void main() {
     expect(find.byType(FirstScreen), findsOneWidget);
   });
 
-  testWidgets("Get.back closeOverlays closes both snackbar and current route",
+  testWidgets(
+      "Get.back with closeOverlays pops both snackbar and current route",
       (tester) async {
-    await tester.pumpWidget(
-      Wrapper(child: FirstScreen()),
-    );
+    await tester.pumpWidget(Wrapper(child: FirstScreen()));
 
     Get.to(SecondScreen());
     Get.snackbar('title', "message");

--- a/test/navigation/get_main_test.dart
+++ b/test/navigation/get_main_test.dart
@@ -227,8 +227,9 @@ void main() {
   testWidgets(
       "Get.offUntil removes previous routes if they don't match predicate",
       (tester) async {
-    await tester.pumpWidget(Wrapper(child: FirstScreen()));
+    await tester.pumpWidget(Wrapper(child: Container()));
 
+    Get.to(FirstScreen());
     Get.to(SecondScreen());
     Get.offUntil(GetPageRoute(page: () => ThirdScreen()),
         (route) => (route as GetPageRoute).routeName == '/FirstScreen');


### PR DESCRIPTION
After #860 I saw that some test check multiple behaviors each and had not very meaningful names. I changed tests in attempt to test exactly one behavior per test and named each test correspondingly. Changes happened in tests for navigation actions mainly, so I haven't changed tests for snackbars, etc. yet.

Hope this change will help with moving forward, especially with adding Navigation 2.0.

There is still space for improvement and I would like to improve more tests in other PRs.