### PR TITLE
solving problem of sending parameters by query parameters

### DIFF
--- a/lib/get_connect/http/src/http.dart
+++ b/lib/get_connect/http/src/http.dart
@@ -77,11 +77,12 @@ class GetHttpClient {
     if (baseUrl != null) {
       url = baseUrl + url;
     }
-    final uri = Uri.parse(url);
-    if (query != null) {
-      return uri.replace(queryParameters: query);
+    if(query != null){
+      final uriParams = Uri(queryParameters: query);
+      url = '$url?${uriParams.query}';
     }
-    return uri;
+    
+    return Uri.parse(url);
   }
 
   Future<Request<T>> _requestWithBody<T>(


### PR DESCRIPTION
I found a problem in using GetConnect in the get method, when I send the query parameter it was not adding the url. I implemented the solution, feel free to analyze and see if it makes sense.

```dart
    final response = await get<List<GiphyModel>>(
      'http://api.giphy.com/v1/gifs/trending',
      query: {'api_key': 'chaveXXX'},
      decoder: (data) {
        return data['data']
            .map<GiphyModel>(
              (d) => GiphyModel(
                d['id'],
                d['images']['original']['url'],
              ),
            )
            .toList();
      },
    );
```