### PR TITLE
Getsocket allowselfsigned

### DIFF
--- a/lib/get_connect/sockets/sockets.dart
+++ b/lib/get_connect/sockets/sockets.dart
@@ -6,5 +6,6 @@ class GetSocket extends BaseWebSocket {
   GetSocket(
     String url, {
     Duration ping = const Duration(seconds: 5),
-  }) : super(url, ping: ping);
+    bool allowSelfSigned = true
+  }) : super(url, ping: ping, allowSelfSigned: allowSelfSigned);
 }

--- a/lib/get_connect/sockets/src/sockets_io.dart
+++ b/lib/get_connect/sockets/src/sockets_io.dart
@@ -18,9 +18,13 @@ class BaseWebSocket {
   WebSocket socket;
   SocketNotifier socketNotifier = SocketNotifier();
   bool isDisposed = false;
-  BaseWebSocket(this.url, {this.ping = const Duration(seconds: 5)});
+  BaseWebSocket(
+    this.url, {
+    this.ping = const Duration(seconds: 5),
+    this.allowSelfSigned = true,
+  });
   Duration ping;
-  bool allowSelfSigned = true;
+  bool allowSelfSigned;
 
   ConnectionStatus connectionStatus;
 

--- a/lib/get_connect/sockets/src/sockets_stub.dart
+++ b/lib/get_connect/sockets/src/sockets_stub.dart
@@ -1,7 +1,12 @@
 class BaseWebSocket {
   String url;
   Duration ping;
-  BaseWebSocket(this.url, {this.ping = const Duration(seconds: 5)}) {
+  bool allowSelfSigned;
+  BaseWebSocket(
+    this.url, {
+    this.ping = const Duration(seconds: 5),
+    allowSelfSigned = true,
+  }) {
     throw 'To use sockets you need dart:io or dart:html';
   }
 

--- a/lib/get_connect/sockets/src/sockets_stub.dart
+++ b/lib/get_connect/sockets/src/sockets_stub.dart
@@ -1,3 +1,5 @@
+import './socket_notifier.dart';
+
 class BaseWebSocket {
   String url;
   Duration ping;
@@ -10,7 +12,44 @@ class BaseWebSocket {
     throw 'To use sockets you need dart:io or dart:html';
   }
 
+  Future connect() async {
+    throw 'To use sockets you need dart:io or dart:html';
+  }
+
+  void onOpen(OpenSocket fn) {
+    throw 'To use sockets you need dart:io or dart:html';
+  }
+
+  void onClose(CloseSocket fn) {
+    throw 'To use sockets you need dart:io or dart:html';
+  }
+
+  void onError(CloseSocket fn) {
+    throw 'To use sockets you need dart:io or dart:html';
+  }
+
+  void onMessage(MessageSocket fn) {
+    throw 'To use sockets you need dart:io or dart:html';
+  }
+  
+  void on(String event, MessageSocket message) {
+    throw 'To use sockets you need dart:io or dart:html';
+  }
+
   void close([int status, String reason]) {
     throw 'To use sockets you need dart:io or dart:html';
   }
+
+  void send(dynamic data) async {
+    throw 'To use sockets you need dart:io or dart:html';
+  }
+
+  void dispose() {
+    throw 'To use sockets you need dart:io or dart:html';
+  }
+
+  void emit(String event, dynamic data) {
+    throw 'To use sockets you need dart:io or dart:html';
+  }
+
 }


### PR DESCRIPTION
1. I made a Websocket Server in NodeJS to test `GetSocket`. I needed to set the URL to `ws://xxx.xxx` and for that I needed the `allowSelfSigned` property to be set to false, but it was fixed in true. Now I put it to be one of the parameters of `GetSocket`. 
P.S.: `GetSocket` worked very well.

2. When instantiating `GetSocket` the code editor only suggested the `close` method, since the others were not yet referenced in `BaseWebSocket (stub)`. I put everyone following the guidelines of the `close` method.