### PR TITLE
Handles Response when there is no content-type and body

### DIFF
--- a/lib/get_connect/http/src/http/io/http_request_io.dart
+++ b/lib/get_connect/http/src/http/io/http_request_io.dart
@@ -56,7 +56,7 @@ class HttpRequestImpl extends HttpRequestBase {
       final body = bodyDecoded<T>(
         request,
         stringBody,
-        response.headers.contentType.mimeType,
+        response.headers.contentType?.mimeType,
       );
 
       return Response(

--- a/lib/get_connect/http/src/http/utils/body_decoder.dart
+++ b/lib/get_connect/http/src/http/utils/body_decoder.dart
@@ -20,7 +20,9 @@ T bodyDecoded<T>(Request<T> request, String stringBody, String mimeType) {
   }
 
   try {
-    if (request.decoder == null) {
+    if (stringBody == '') {
+      body = null;
+    } else if (request.decoder == null) {
       body = bodyToDecode as T;
     } else {
       body = request.decoder(bodyToDecode);


### PR DESCRIPTION
Allows GetConnect to work with APIs that do not return Content-Type and/or Body equal to null

Fixes #884 