### PR TITLE
Body string for content-type application/x-www-form-urlencoded

### DIFF
--- a/lib/get_connect/http/src/http.dart
+++ b/lib/get_connect/http/src/http.dart
@@ -117,6 +117,10 @@ class GetHttpClient {
           jsonString = '$paramName=${Uri.encodeQueryComponent(jsonString)}';
         }
       }
+    } else if (body is String) {
+      bodyBytes = utf8.encode(body);
+      headers['content-length'] = bodyBytes.length.toString();
+      headers['content-type'] = contentType ?? defaultContentType;
     } else if (body == null) {
       headers['content-type'] = contentType ?? defaultContentType;
       headers['content-length'] = '0';


### PR DESCRIPTION
To make a request with content-type `application/x-www-form-urlencoded` it is necessary that the body be a string and GetConnect did not accept the body as a string.
Example:
```dart
post(
  'https://api.example.com.br/auth',
  'user=eduardo&password='123',
  contentType: 'application/x-www-form-urlencoded',
);
```