### PR TITLE
Another translation option with parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,27 @@ var products = [];
 Text('singularKey'.trPlural('pluralKey', products.length, Args));
 ```
 
+#### Using translation with parameters
+
+```dart
+import 'package:get/get.dart';
+
+
+Map<String, Map<String, String>> get keys => {
+    'en_US': {
+        'logged_in': 'logged in as @name with email @email',
+    },
+    'es_ES': {
+       'logged_in': 'iniciado sesión como @name con e-mail @email',
+    }
+};
+
+Text('logged_in'.trParams({
+  'name': 'Jhon',
+  'email': 'jhon@example.com'
+  }));
+```
+
 ### Locales
 
 Pass parameters to `GetMaterialApp` to define the locale and translations.

--- a/lib/get_utils/src/extensions/internacionalization.dart
+++ b/lib/get_utils/src/extensions/internacionalization.dart
@@ -58,7 +58,6 @@ extension Trans on String {
     var trans = tr;
     if (params.isNotEmpty) {
       params.forEach((key, value) {
-        print(key);
         trans = trans.replaceAll('@$key', value);
       });
     }

--- a/lib/get_utils/src/extensions/internacionalization.dart
+++ b/lib/get_utils/src/extensions/internacionalization.dart
@@ -53,6 +53,22 @@ extension Trans on String {
   String trPlural([String pluralKey, int i, List<String> args = const []]) {
     return i > 1 ? pluralKey.trArgs(args) : trArgs(args);
   }
+
+  String trParams([Map<String, String> params = const {}]) {
+    var trans = tr;
+    if (params.isNotEmpty) {
+      params.forEach((key, value) {
+        print(key);
+        trans = trans.replaceAll('\$$key', value);
+      });
+    }
+    return trans;
+  }
+
+  String trPluralParams(
+      [String pluralKey, int i, Map<String, String> params = const {}]) {
+    return i > 1 ? pluralKey.trParams(params) : trParams(params);
+  }
 }
 
 class _IntlHost {

--- a/lib/get_utils/src/extensions/internacionalization.dart
+++ b/lib/get_utils/src/extensions/internacionalization.dart
@@ -59,7 +59,7 @@ extension Trans on String {
     if (params.isNotEmpty) {
       params.forEach((key, value) {
         print(key);
-        trans = trans.replaceAll('\$$key', value);
+        trans = trans.replaceAll('@$key', value);
       });
     }
     return trans;


### PR DESCRIPTION
- trArgs is not very intuitive, and not very useful when you have to pass several parameters.
- trParams use the map, it is more intuitive to pass parameters
```dart
import 'package:get/get.dart';


Map<String, Map<String, String>> get keys => {
    'en_US': {
        'logged_in': 'logged in as @name with email @email',
    },
    'es_ES': {
       'logged_in': 'iniciado sesión como @name con e-mail @email',
    }
};

Text('logged_in'.trParams({
  'name': 'Jhon',
  'email': 'jhon@example.com'
  })); /// logged in as Jhon with email jhon@example.com
```