### PR TITLE
Remove '=>' unnecessary

### DIFF
--- a/documentation/en_US/dependency_management.md
+++ b/documentation/en_US/dependency_management.md
@@ -81,9 +81,9 @@ It is possible to lazyLoad a dependency so that it will be instantiated only whe
 Get.lazyPut<ApiMock>(() => ApiMock());
 
 Get.lazyPut<FirebaseAuth>(
-  () => {
-  // ... some logic if needed
-    return FirebaseAuth()
+  () {
+    // ... some logic if needed
+    return FirebaseAuth();
   },
   tag: Math.random().toString(),
   fenix: true
@@ -309,7 +309,7 @@ getPages: [
   GetPage(
     name: '/',
     page: () => HomeView(),
-    binding: BindingsBuilder(() => {
+    binding: BindingsBuilder(() {
       Get.lazyPut<ControllerX>(() => ControllerX());
       Get.put<Service>(()=> Api());
     }),
@@ -317,7 +317,7 @@ getPages: [
   GetPage(
     name: '/details',
     page: () => DetailsView(),
-    binding: BindingsBuilder(() => {
+    binding: BindingsBuilder(() {
       Get.lazyPut<DetailsController>(() => DetailsController());
     }),
   ),

--- a/documentation/en_US/route_management.md
+++ b/documentation/en_US/route_management.md
@@ -484,12 +484,12 @@ Get.bottomSheet(
         ListTile(
           leading: Icon(Icons.music_note),
           title: Text('Music'),
-          onTap: () => {}
+          onTap: () {}
         ),
         ListTile(
           leading: Icon(Icons.videocam),
           title: Text('Video'),
-          onTap: () => {},
+          onTap: () {},
         ),
       ],
     ),

--- a/documentation/es_ES/route_management.md
+++ b/documentation/es_ES/route_management.md
@@ -484,12 +484,12 @@ Get.bottomSheet(
         ListTile(
           leading: Icon(Icons.music_note),
           title: Text('Music'),
-          onTap: () => {}
+          onTap: () {}
         ),
         ListTile(
           leading: Icon(Icons.videocam),
           title: Text('Video'),
-          onTap: () => {},
+          onTap: () {},
         ),
       ],
     ),

--- a/documentation/id_ID/dependency_management.md
+++ b/documentation/id_ID/dependency_management.md
@@ -84,9 +84,9 @@ Anda bisa melakukan lazyload terhadap sebuah dependensi supaya dependensi terseb
 Get.lazyPut<ApiMock>(() => ApiMock());
 
 Get.lazyPut<FirebaseAuth>(
-  () => {
-  // ... beberapa logic jika diperlukan..
-    return FirebaseAuth()
+  () {
+    // ... beberapa logic jika diperlukan..
+    return FirebaseAuth();
   },
   tag: Math.random().toString(),
   fenix: true
@@ -322,7 +322,7 @@ getPages: [
   GetPage(
     name: '/',
     page: () => HomeView(),
-    binding: BindingsBuilder(() => {
+    binding: BindingsBuilder(() {
       Get.lazyPut<ControllerX>(() => ControllerX());
       Get.put<Service>(()=> Api());
     }),
@@ -330,7 +330,7 @@ getPages: [
   GetPage(
     name: '/details',
     page: () => DetailsView(),
-    binding: BindingsBuilder(() => {
+    binding: BindingsBuilder(() {
       Get.lazyPut<DetailsController>(() => DetailsController());
     }),
   ),

--- a/documentation/id_ID/route_management.md
+++ b/documentation/id_ID/route_management.md
@@ -486,12 +486,12 @@ Get.bottomSheet(
         ListTile(
           leading: Icon(Icons.music_note),
           title: Text('Music'),
-          onTap: () => {}
+          onTap: () {}
         ),
         ListTile(
           leading: Icon(Icons.videocam),
           title: Text('Video'),
-          onTap: () => {},
+          onTap: () {},
         ),
       ],
     ),

--- a/documentation/kr_KO/dependency_management.md
+++ b/documentation/kr_KO/dependency_management.md
@@ -80,9 +80,9 @@ Get.put<S>(
 Get.lazyPut<ApiMock>(() => ApiMock());
 
 Get.lazyPut<FirebaseAuth>(
-  () => {
-  // 어떤 로직이 필요하다면 ...
-    return FirebaseAuth()
+  () {
+    // 어떤 로직이 필요하다면 ...
+    return FirebaseAuth();
   },
   tag: Math.random().toString(),
   fenix: true
@@ -308,7 +308,7 @@ getPages: [
   GetPage(
     name: '/',
     page: () => HomeView(),
-    binding: BindingsBuilder(() => {
+    binding: BindingsBuilder(() {
       Get.lazyPut<ControllerX>(() => ControllerX());
       Get.put<Service>(()=> Api());
     }),
@@ -316,7 +316,7 @@ getPages: [
   GetPage(
     name: '/details',
     page: () => DetailsView(),
-    binding: BindingsBuilder(() => {
+    binding: BindingsBuilder(() {
       Get.lazyPut<DetailsController>(() => DetailsController());
     }),
   ),

--- a/documentation/kr_KO/route_management.md
+++ b/documentation/kr_KO/route_management.md
@@ -484,12 +484,12 @@ Get.bottomSheet(
         ListTile(
           leading: Icon(Icons.music_note),
           title: Text('Music'),
-          onTap: () => {}
+          onTap: () {}
         ),
         ListTile(
           leading: Icon(Icons.videocam),
           title: Text('Video'),
-          onTap: () => {},
+          onTap: () {},
         ),
       ],
     ),

--- a/documentation/pt_BR/dependency_management.md
+++ b/documentation/pt_BR/dependency_management.md
@@ -83,9 +83,9 @@ Nesses casos pode ser usado o lazyPut que só cria a instância no momento que e
 Get.lazyPut<ApiMock>(() => ApiMock());
 
 Get.lazyPut<FirebaseAuth>(
-  () => {
-  // ... alguma lógica se necessário
-    return FirebaseAuth()
+  () {
+    // ... alguma lógica se necessário
+    return FirebaseAuth();
   },
   tag: Math.random().toString(),
   fenix: true
@@ -313,7 +313,7 @@ getPages: [
   GetPage(
     name: '/',
     page: () => HomeView(),
-    binding: BindingsBuilder(() => {
+    binding: BindingsBuilder(() {
       Get.lazyPut<ControllerX>(() => ControllerX());
       Get.put<Service>(()=> Api());
     }),
@@ -321,7 +321,7 @@ getPages: [
   GetPage(
     name: '/detalhes',
     page: () => DetalhesView(),
-    binding: BindingsBuilder(() => {
+    binding: BindingsBuilder(() {
       Get.lazyPut<DetalhesController>(() => DetalhesController());
     }),
   ),

--- a/documentation/pt_BR/route_management.md
+++ b/documentation/pt_BR/route_management.md
@@ -195,12 +195,12 @@ Get.bottomSheet(
         ListTile(
           leading: Icon(Icons.music_note),
           title: Text('Música'),
-          onTap: () => {}
+          onTap: () {}
         ),
         ListTile(
           leading: Icon(Icons.videocam),
           title: Text('Vídeo'),
-          onTap: () => {},
+          onTap: () {},
         ),
       ],
     ),

--- a/documentation/ru_RU/dependency_management.md
+++ b/documentation/ru_RU/dependency_management.md
@@ -81,9 +81,9 @@ Get.put<S>(
 Get.lazyPut<ApiMock>(() => ApiMock());
 
 Get.lazyPut<FirebaseAuth>(
-  () => {
-  // ... some logic if needed
-    return FirebaseAuth()
+  () {
+    // ... some logic if needed
+    return FirebaseAuth();
   },
   tag: Math.random().toString(),
   fenix: true
@@ -309,7 +309,7 @@ getPages: [
   GetPage(
     name: '/',
     page: () => HomeView(),
-    binding: BindingsBuilder(() => {
+    binding: BindingsBuilder(() {
       Get.lazyPut<ControllerX>(() => ControllerX());
       Get.put<Service>(()=> Api());
     }),
@@ -317,7 +317,7 @@ getPages: [
   GetPage(
     name: '/details',
     page: () => DetailsView(),
-    binding: BindingsBuilder(() => {
+    binding: BindingsBuilder(() {
       Get.lazyPut<DetailsController>(() => DetailsController());
     }),
   ),

--- a/documentation/ru_RU/route_management.md
+++ b/documentation/ru_RU/route_management.md
@@ -484,12 +484,12 @@ Get.bottomSheet(
         ListTile(
           leading: Icon(Icons.music_note),
           title: Text('Music'),
-          onTap: () => {}
+          onTap: () {}
         ),
         ListTile(
           leading: Icon(Icons.videocam),
           title: Text('Video'),
-          onTap: () => {},
+          onTap: () {},
         ),
       ],
     ),

--- a/documentation/zh_CN/dependency_management.md
+++ b/documentation/zh_CN/dependency_management.md
@@ -81,9 +81,9 @@ Get.put<S>(
 Get.lazyPut<ApiMock>(() => ApiMock());
 
 Get.lazyPut<FirebaseAuth>(
-  () => {
-  // ... some logic if needed
-    return FirebaseAuth()
+  () {
+    // ... some logic if needed
+    return FirebaseAuth();
   },
   tag: Math.random().toString(),
   fenix: true
@@ -306,7 +306,7 @@ getPages: [
   GetPage(
     name: '/',
     page: () => HomeView(),
-    binding: BindingsBuilder(() => {
+    binding: BindingsBuilder(() {
       Get.lazyPut<ControllerX>(() => ControllerX());
       Get.put<Service>(()=> Api());
     }),
@@ -314,7 +314,7 @@ getPages: [
   GetPage(
     name: '/details',
     page: () => DetailsView(),
-    binding: BindingsBuilder(() => {
+    binding: BindingsBuilder(() {
       Get.lazyPut<DetailsController>(() => DetailsController());
     }),
   ),

--- a/documentation/zh_CN/route_management.md
+++ b/documentation/zh_CN/route_management.md
@@ -478,12 +478,12 @@ Get.bottomSheet(
         ListTile(
           leading: Icon(Icons.music_note),
           title: Text('Music'),
-          onTap: () => {}
+          onTap: () {}
         ),
         ListTile(
           leading: Icon(Icons.videocam),
           title: Text('Video'),
-          onTap: () => {},
+          onTap: () {},
         ),
       ],
     ),

--- a/test/navigation/bottomsheet_test.dart
+++ b/test/navigation/bottomsheet_test.dart
@@ -13,9 +13,10 @@ void main() {
       child: Wrap(
         children: <Widget>[
           ListTile(
-              leading: Icon(Icons.music_note),
-              title: Text('Music'),
-              onTap: () => {}),
+            leading: Icon(Icons.music_note),
+            title: Text('Music'),
+            onTap: () {},
+          ),
         ],
       ),
     ));
@@ -34,9 +35,10 @@ void main() {
       child: Wrap(
         children: <Widget>[
           ListTile(
-              leading: Icon(Icons.music_note),
-              title: Text('Music'),
-              onTap: () => {}),
+            leading: Icon(Icons.music_note),
+            title: Text('Music'),
+            onTap: () {},
+          ),
         ],
       ),
     ));


### PR DESCRIPTION
Removed all instances of "=>" that are unnecessary from the documentation and a test file

Fixes #966 