### PR TITLE
Utils: capitalize cannot convert space to null

### DIFF
--- a/lib/get_utils/src/get_utils/get_utils.dart
+++ b/lib/get_utils/src/get_utils/get_utils.dart
@@ -518,17 +518,16 @@ class GetUtils {
   /// Capitalize each word inside string
   /// Example: your name => Your Name, your name => Your name
   static String capitalize(String value) {
-    if (isNullOrBlank(value)) return null;
+    if (isNull(value)) return null;
+    if (isBlank(value)) return value;
     return value.split(' ').map(capitalizeFirst).join(' ');
   }
 
   /// Uppercase first letter inside string and let the others lowercase
   /// Example: your name => Your name
   static String capitalizeFirst(String s) {
-    if (isNullOrBlank(s)) {
-      return null;
-    }
-
+    if (isNull(s)) return null;
+    if (isBlank(s)) return s;
     return s[0].toUpperCase() + s.substring(1).toLowerCase();
   }
 

--- a/test/utils/extensions/string_extensions_test.dart
+++ b/test/utils/extensions/string_extensions_test.dart
@@ -679,14 +679,17 @@ void main() {
       expect('foo bar'.capitalize, 'Foo Bar');
       expect('FoO bAr'.capitalize, 'Foo Bar');
       expect('FOO BAR'.capitalize, 'Foo Bar');
-      expect(''.capitalize, null);
+      expect(null.capitalize, null);
+      expect(''.capitalize, '');
+      expect('foo  bar '.capitalize, 'Foo  Bar ');
     });
 
     test('var.capitalizeFirst', () {
       expect('foo bar'.capitalizeFirst, 'Foo bar');
       expect('FoO bAr'.capitalizeFirst, 'Foo bar');
       expect('FOO BAR'.capitalizeFirst, 'Foo bar');
-      expect(''.capitalizeFirst, null);
+      expect(null.capitalizeFirst, null);
+      expect(''.capitalizeFirst, '');
     });
 
     test('var.removeAllWhitespace', () {


### PR DESCRIPTION
If the string is 'getx\<space\>\<space\>package\<space\>'
`capitalize` resulted in this string:  **Getx null Package null** 

With this PR the result is `Getx  Package `

Fixes #972 