### PR TITLE
includes GetLifeCycleBase mixin on delete/dispose

### DIFF
--- a/lib/get_instance/src/get_instance.dart
+++ b/lib/get_instance/src/get_instance.dart
@@ -388,9 +388,9 @@ class GetInstance {
       return false;
     }
 
-    if (i is GetLifeCycle) {
+    if (i is GetLifeCycleBase && i.onDelete != null) {
       i.onDelete();
-      Get.log('"$newKey" onClose() called');
+      Get.log('"$newKey" onDelete() called');
     }
 
     _singl.remove(newKey);


### PR DESCRIPTION
Not sure is this is bug or a desired behavior. But there are some situations where need to inject or binding a class that already have another base class, e.g. an existing BLoC/Cubit, and my only option is to add `GetLifeCycleBase` mixin to they. 

Because of that looks like makes sense "Get Instance Manager" looks for `GetLifeCycleBase` on `delete()` and not only `GetLifeCycle` to corretly dispose they. 

```dart
class SignUpCubit extends Cubit<SignUpState> with GetLifeCycleBase {

  SignUpCubit() : super(SignUpState.valid()) {
    $configureLifeCycle();
  }
  [...]

  @override
   void onClose() {
     close(); // close bloc stream
  }
}
```

Another [better imho] option is `delete()` even test if the instance to delete is `Sink/Stream` and right close() then before remove from map, something like 
```dart 
if (i is GetLifeCycleBase && i.onDelete != null) {
      i.onDelete();
      Get.log('"$newKey" onDelete() called');
    }	    
}

if (i is Sink) {
    i.close();
    Get.log('"$newKey" is a Sink, close() called');
}
```

I can add the second test if it makes sense, just let me know.