### PR TITLE
fixed the log when using builder instead of widget on Get.to().

### DIFF
--- a/lib/get_navigation/src/extension_navigation.dart
+++ b/lib/get_navigation/src/extension_navigation.dart
@@ -498,7 +498,12 @@ extension GetNavigation on GetInterface {
     bool preventDuplicates = true,
     bool popGesture,
   }) {
-    var routeName = "/${page.runtimeType.toString()}";
+    String routeName;
+    if (page is GetPageBuilder) {
+      routeName = "/${page().runtimeType.toString()}";
+    } else {
+      routeName = "/${page.runtimeType.toString()}";
+    }
     if (preventDuplicates && routeName == currentRoute) {
       return null;
     }


### PR DESCRIPTION
When routing using the builder instead of the widget on Get.to the Get.log was printing the builder instead of the name of the widget.