### PR TITLE
Fixed bug when bodyBytes is null

### DIFF
--- a/lib/get_connect/http/src/http.dart
+++ b/lib/get_connect/http/src/http.dart
@@ -139,7 +139,7 @@ class GetHttpClient {
       url: uri,
       headers: headers,
       bodyBytes: bodyStream,
-      contentLength: bodyBytes.length,
+      contentLength: bodyBytes?.length ?? 0,
       followRedirects: followRedirects,
       maxRedirects: maxRedirects,
       decoder: decoder,


### PR DESCRIPTION
When body is empty, the bodyBytes will be null, hence causing following null error:
E/flutter (28391): [ERROR:flutter/lib/ui/ui_dart_state.cc(177)] Unhandled Exception: NoSuchMethodError: The getter 'length' was called on null.

Fixed by null checking.