### PR TITLE
Create an Event Rx holder to call listeners when the same value is passed

### DIFF
--- a/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
+++ b/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
@@ -379,6 +379,30 @@ class Rx<T> extends _RxImpl<T> {
   }
 }
 
+/// Similar class to Rx<T> but this also will refresh the listeners if the same
+/// value has been provided. This is useful when maintaining a state with the
+/// same user = User("foo").
+/// For example, supposed we have a `int seconds = 2` and we want to animate
+/// from invisible to visible a widget in two seconds:
+/// RxEvent<int>.call(seconds);
+/// then after a click happens, you want to call a RxEvent<int>.call(seconds).
+/// This will refresh the listener of an AnimatedWidget and will keep the value
+/// if the Rx is kept in memory.
+///
+class RxEvent<T> extends Rx<T> {
+  RxEvent([T initial]) : super(initial);
+
+  void trigger([T v]) {
+    var firstRebuild = this.firstRebuild;
+    value = v;
+    // If it's not the first rebuild, the listeners have been called already
+    // So we won't call them again.
+    if (!firstRebuild) {
+      subject.add(v);
+    }
+  }
+}
+
 extension StringExtension on String {
   /// Returns a `RxString` with [this] `String` as initial value.
   RxString get obs => RxString(this);

--- a/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
+++ b/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
@@ -199,6 +199,41 @@ abstract class _RxImpl<T> extends RxNotifier<T> with RxObjectMixin<T> {
     fn(_value);
     subject.add(_value);
   }
+
+  /// Following certain practices on Rx data, we might want to react to certain
+  /// listeners when a value has been provided, even if the value is the same.
+  /// At the moment, we ignore part of the process if we `.call(value)` with
+  /// the same value since it holds the value and there's no real
+  /// need triggering the entire process for the same value inside, but
+  /// there are other situations where we might be interested in
+  /// triggering this.
+  ///
+  /// For example, supposed we have a `int seconds = 2` and we want to animate
+  /// from invisible to visible a widget in two seconds:
+  /// RxEvent<int>.call(seconds);
+  /// then after a click happens, you want to call a RxEvent<int>.call(seconds).
+  /// By doing `call(seconds)`, if the value being held is the same,
+  /// the listeners won't trigger, hence we need this new `trigger` function.
+  /// This will refresh the listener of an AnimatedWidget and will keep
+  /// the value if the Rx is kept in memory.
+  /// Sample:
+  /// ```
+  /// Rx<Int> secondsRx = RxInt();
+  /// secondsRx.listen((value) => print("$value seconds set"));
+  ///
+  /// secondsRx.call(2);      // This won't trigger any listener, since the value is the same
+  /// secondsRx.trigger(2);   // This will trigger the listener independently from the value.
+  /// ```
+  ///
+  void trigger([T v]) {
+    var firstRebuild = this.firstRebuild;
+    value = v;
+    // If it's not the first rebuild, the listeners have been called already
+    // So we won't call them again.
+    if (!firstRebuild) {
+      subject.add(v);
+    }
+  }
 }
 
 /// Rx class for `bool` Type.
@@ -375,30 +410,6 @@ class Rx<T> extends _RxImpl<T> {
       return (value as dynamic)?.toJson();
     } on Exception catch (_) {
       throw '$T has not method [toJson]';
-    }
-  }
-}
-
-/// Similar class to Rx<T> but this also will refresh the listeners if the same
-/// value has been provided. This is useful when maintaining a state with the
-/// same user = User("foo").
-/// For example, supposed we have a `int seconds = 2` and we want to animate
-/// from invisible to visible a widget in two seconds:
-/// RxEvent<int>.call(seconds);
-/// then after a click happens, you want to call a RxEvent<int>.call(seconds).
-/// This will refresh the listener of an AnimatedWidget and will keep the value
-/// if the Rx is kept in memory.
-///
-class RxEvent<T> extends Rx<T> {
-  RxEvent([T initial]) : super(initial);
-
-  void trigger([T v]) {
-    var firstRebuild = this.firstRebuild;
-    value = v;
-    // If it's not the first rebuild, the listeners have been called already
-    // So we won't call them again.
-    if (!firstRebuild) {
-      subject.add(v);
     }
   }
 }

--- a/test/rx/rx_workers_test.dart
+++ b/test/rx/rx_workers_test.dart
@@ -95,4 +95,55 @@ void main() {
     await Future.delayed(Duration.zero);
     expect(count, 555);
   });
+
+  test('Rx same value will not call the same listener', () async {
+    var reactiveInteger = RxInt(2);
+    var timesCalled = 0;
+    reactiveInteger.listen((newInt) {
+      timesCalled++;
+    });
+
+    // we call 3
+    reactiveInteger.call(3);
+    // then repeat twice
+    reactiveInteger.call(3);
+    reactiveInteger.call(3);
+
+    await Future.delayed(Duration(milliseconds: 100));
+    expect(1, timesCalled);
+  });
+
+  test('RxEvent same value will trigger the listener when trigger', () async {
+    var reactiveInteger = RxEvent<int>(2);
+    var timesCalled = 0;
+    reactiveInteger.listen((newInt) {
+      timesCalled++;
+    });
+
+    // we call 3
+    reactiveInteger.trigger(3);
+    // then repeat twice
+    reactiveInteger.trigger(3);
+    reactiveInteger.trigger(3);
+
+    await Future.delayed(Duration(milliseconds: 100));
+    expect(3, timesCalled);
+  });
+
+  test('RxEvent same value will not trigger the listener when call', () async {
+    var reactiveInteger = RxEvent<int>(2);
+    var timesCalled = 0;
+    reactiveInteger.listen((newInt) {
+      timesCalled++;
+    });
+
+    // we call 3
+    reactiveInteger.call(3);
+    // then repeat twice
+    reactiveInteger.call(3);
+    reactiveInteger.call(3);
+
+    await Future.delayed(Duration(milliseconds: 100));
+    expect(1, timesCalled);
+  });
 }

--- a/test/rx/rx_workers_test.dart
+++ b/test/rx/rx_workers_test.dart
@@ -96,7 +96,7 @@ void main() {
     expect(count, 555);
   });
 
-  test('Rx same value will not call the same listener', () async {
+  test('Rx same value will not call the same listener when `call`', () async {
     var reactiveInteger = RxInt(2);
     var timesCalled = 0;
     reactiveInteger.listen((newInt) {
@@ -113,8 +113,8 @@ void main() {
     expect(1, timesCalled);
   });
 
-  test('RxEvent same value will trigger the listener when trigger', () async {
-    var reactiveInteger = RxEvent<int>(2);
+  test('Rx same value will call the listener when `trigger`', () async {
+    var reactiveInteger = RxInt(2);
     var timesCalled = 0;
     reactiveInteger.listen((newInt) {
       timesCalled++;
@@ -128,22 +128,5 @@ void main() {
 
     await Future.delayed(Duration(milliseconds: 100));
     expect(3, timesCalled);
-  });
-
-  test('RxEvent same value will not trigger the listener when call', () async {
-    var reactiveInteger = RxEvent<int>(2);
-    var timesCalled = 0;
-    reactiveInteger.listen((newInt) {
-      timesCalled++;
-    });
-
-    // we call 3
-    reactiveInteger.call(3);
-    // then repeat twice
-    reactiveInteger.call(3);
-    reactiveInteger.call(3);
-
-    await Future.delayed(Duration(milliseconds: 100));
-    expect(1, timesCalled);
   });
 }


### PR DESCRIPTION
This idea comes half-way from the [SingleLiveEvent of Android and Kotlin](https://medium.com/@abhiappmobiledeveloper/android-singleliveevent-of-livedata-for-ui-event-35d0c58512da), although this one doesn't keep the value afterwards (maybe if it's interesting, I can make it work in both ways!); this new `RxEvent<T>` will notify the listeners through `RxEvent<T>.trigger(T)`.

Imagine you're creating an `Obx(builder)` where the builder animates a Widget for `2` seconds, and you want to animate that according to a logic variable: `RxEvent<int> secondsAnimation = RxEvent<int>(2)`. After an user iteration, you might want to animate that again to 2 seconds as well: `secondsAnimation.trigger(2)` will trigger the listeners again (`.call(2)` or `.value = 2` won't!). 

I'm up to hear some feedback, or event remove entirely the `RxEvent<T>` class and add the `.trigger(T)` method into `Rx<T>`.