### PR TITLE
Fix content length equals null, need to be zero instead

### DIFF
--- a/lib/get_connect/http/src/http.dart
+++ b/lib/get_connect/http/src/http.dart
@@ -139,7 +139,7 @@ class GetHttpClient {
       url: uri,
       headers: headers,
       bodyBytes: bodyStream,
-      contentLength: bodyBytes.length,
+      contentLength: bodyBytes?.length ?? 0,
       followRedirects: followRedirects,
       maxRedirects: maxRedirects,
       decoder: decoder,
@@ -251,6 +251,7 @@ class GetHttpClient {
       url: uri,
       headers: headers,
       decoder: decoder ?? (defaultDecoder as Decoder<T>),
+      contentLength: 0,
     ));
   }
 


### PR DESCRIPTION
Now instead null when you will make a get request the content length will be zero instead null.