### PR TITLE
Get.put/putAsync/find not nullable

### DIFF
--- a/example/test/main_test.dart
+++ b/example/test/main_test.dart
@@ -6,8 +6,8 @@ import 'package:get/get.dart';
 import 'package:get_demo/pages/home/domain/adapters/repository_adapter.dart';
 import 'package:get_demo/pages/home/domain/entity/cases_model.dart';
 import 'package:get_demo/pages/home/presentation/controllers/home_controller.dart';
-import 'package:get_demo/routes/app_pages.dart';
-import 'package:get_test/get_test.dart';
+// import 'package:get_demo/routes/app_pages.dart';
+// import 'package:get_test/get_test.dart';
 import 'package:matcher/matcher.dart' as m;
 
 class MockRepository implements IHomeRepository {
@@ -37,11 +37,12 @@ class MockRepository implements IHomeRepository {
 }
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
   setUpAll(() => HttpOverrides.global = null);
   final binding = BindingsBuilder(() {
     Get.lazyPut<IHomeRepository>(() => MockRepository());
     Get.lazyPut<HomeController>(
-        () => HomeController(homeRepository: Get.find()!));
+        () => HomeController(homeRepository: Get.find()));
   });
 
   test('Test Binding', () {
@@ -86,7 +87,9 @@ void main() {
   });
 
   /// Tests with GetTests
-  getTest(
+  /// TEMPORARILY REMOVED from the null-safetym branch as
+  /// get_test is not yet null safety.
+  /* getTest(
     "test description",
     getPages: AppPages.routes,
     initialRoute: AppPages.INITIAL,
@@ -135,7 +138,7 @@ void main() {
     onClose: (c) {
       print('onClose');
     },
-  );
+  );*/
 }
 
 class Controller extends GetxController {

--- a/lib/get_instance/src/extension_instance.dart
+++ b/lib/get_instance/src/extension_instance.dart
@@ -39,7 +39,7 @@ extension Inst on GetInterface {
   /// async version of [Get.put()].
   /// Awaits for the resolution of the Future from [builder()] parameter and
   /// stores the Instance returned.
-  Future<S?> putAsync<S>(AsyncInstanceBuilderCallback<S> builder,
+  Future<S> putAsync<S>(AsyncInstanceBuilderCallback<S> builder,
           {String? tag, bool permanent = false}) async =>
       GetInstance().putAsync<S>(builder, tag: tag, permanent: permanent);
 
@@ -67,7 +67,7 @@ extension Inst on GetInterface {
   /// Finds a Instance of the required Class <[S]>(or [tag])
   /// In the case of using [Get.create()], it will generate an Instance
   /// each time you call [Get.find()].
-  S find<S>({String? tag}) => GetInstance().find<S>(tag: tag)!;
+  S find<S>({String? tag}) => GetInstance().find<S>(tag: tag);
 
   /// Injects an [Instance<S>] in memory.
   ///
@@ -83,7 +83,7 @@ extension Inst on GetInterface {
   /// rules. Although, can be removed by [GetInstance.reset()]
   /// and [Get.delete()]
   /// - [builder] If defined, the [dependency] must be returned from here
-  S? put<S>(S dependency,
+  S put<S>(S dependency,
           {String? tag,
           bool permanent = false,
           InstanceBuilderCallback<S>? builder}) =>

--- a/lib/get_instance/src/get_instance.dart
+++ b/lib/get_instance/src/get_instance.dart
@@ -28,7 +28,7 @@ class GetInstance {
 
   static GetInstance? _getInstance;
 
-  T? call<T>() => find<T>();
+  T call<T>() => find<T>();
 
   /// Holds references to every registered Instance when using
   /// [Get.put()]
@@ -69,7 +69,7 @@ class GetInstance {
   /// async version of [Get.put()].
   /// Awaits for the resolution of the Future from [builder()] parameter and
   /// stores the Instance returned.
-  Future<S?> putAsync<S>(
+  Future<S> putAsync<S>(
     AsyncInstanceBuilderCallback<S> builder, {
     String? tag,
     bool permanent = false,
@@ -87,7 +87,7 @@ class GetInstance {
   /// the same Type<[S]>
   /// - [permanent] keeps the Instance in memory, not following
   /// [Get.smartManagement] rules.
-  S? put<S>(
+  S put<S>(
     S dependency, {
     String? tag,
     bool permanent = false,
@@ -277,9 +277,9 @@ class GetInstance {
   }
 
   /// Initializes the controller
-  S? _startController<S>({String? tag}) {
+  S _startController<S>({String? tag}) {
     final key = _getKey(S, tag);
-    final i = _singl[key]!.getDependency() as S?;
+    final i = _singl[key]!.getDependency() as S;
     if (i is GetLifeCycleBase) {
       i.onStart();
       if (tag == null) {
@@ -289,17 +289,18 @@ class GetInstance {
       }
       if (!_singl[key]!.isSingleton!) {
         _routesByCreate[Get.reference] ??= HashSet<Function>();
-        _routesByCreate[Get.reference]!.add(i.onDelete as Function);
+        // _routesByCreate[Get.reference]!.add(i.onDelete as Function);
+        _routesByCreate[Get.reference]!.add(i.onDelete);
       }
     }
     return i;
   }
 
-  S? putOrFind<S>(InstanceBuilderCallback<S> dep, {String? tag}) {
+  S putOrFind<S>(InstanceBuilderCallback<S> dep, {String? tag}) {
     final key = _getKey(S, tag);
 
     if (_singl.containsKey(key)) {
-      return _singl[key]!.getDependency() as S?;
+      return _singl[key]!.getDependency() as S;
     } else {
       return GetInstance().put(dep(), tag: tag);
     }
@@ -310,7 +311,7 @@ class GetInstance {
   /// it will create an instance each time you call [find].
   /// If the registered type <[S]> (or [tag]) is a Controller,
   /// it will initialize it's lifecycle.
-  S? find<S>({String? tag}) {
+  S find<S>({String? tag}) {
     final key = _getKey(S, tag);
     if (isRegistered<S>(tag: tag)) {
       if (_singl[key] == null) {
@@ -325,7 +326,7 @@ class GetInstance {
       /// `initDependencies`, so we have to return the instance from there
       /// to make it compatible with `Get.create()`.
       final i = _initDependencies<S>(name: tag);
-      return i ?? _singl[key]!.getDependency() as S?;
+      return i ?? _singl[key]!.getDependency() as S;
     } else {
       // ignore: lines_longer_than_80_chars
       throw '"$S" not found. You need to call "Get.put($S())" or "Get.lazyPut(()=>$S())"';
@@ -513,13 +514,13 @@ class _InstanceBuilderFactory<S> {
   }
 
   /// Gets the actual instance by it's [builderFunc] or the persisted instance.
-  S? getDependency() {
+  S getDependency() {
     if (isSingleton!) {
       if (dependency == null) {
         _showInitLog();
         dependency = builderFunc();
       }
-      return dependency;
+      return dependency!;
     } else {
       return builderFunc();
     }

--- a/test/instance/get_instance_test.dart
+++ b/test/instance/get_instance_test.dart
@@ -136,7 +136,7 @@ void main() {
     tearDownAll(Get.reset);
 
     test('Get.put test with init check', () async {
-      final instance = Get.put(DisposableController())!;
+      final instance = Get.put(DisposableController());
       expect(instance, Get.find<DisposableController>());
       expect(instance.initialized, true);
     });
@@ -150,7 +150,7 @@ void main() {
 
     test('Get.put test after delete with disposable controller and init check',
         () async {
-      final instance = Get.put<DisposableController>(DisposableController())!;
+      final instance = Get.put<DisposableController>(DisposableController());
       expect(instance, Get.find<DisposableController>());
       expect(instance.initialized, true);
     });

--- a/test/state_manager/get_mixin_state_test.dart
+++ b/test/state_manager/get_mixin_state_test.dart
@@ -51,7 +51,7 @@ void main() {
     expect(find.text("List: 0"), findsOneWidget);
     expect(find.text("Map: 0"), findsOneWidget);
 
-    Controller.to!.increment();
+    Controller.to.increment();
 
     await tester.pump();
 
@@ -79,7 +79,7 @@ void main() {
 }
 
 class Controller extends GetxController {
-  static Controller? get to => Get.find();
+  static Controller get to => Get.find();
   int count = 0;
   RxInt counter = 0.obs;
   RxDouble doubleNum = 0.0.obs;

--- a/test/state_manager/get_obx_test.dart
+++ b/test/state_manager/get_obx_test.dart
@@ -11,7 +11,7 @@ void main() {
           children: [
             Obx(
               () => Column(children: [
-                Text('Count: ${controller!.counter.value}'),
+                Text('Count: ${controller.counter.value}'),
                 Text('Double: ${controller.doubleNum.value}'),
                 Text('String: ${controller.string.value}'),
                 Text('List: ${controller.list.length}'),
@@ -37,7 +37,7 @@ void main() {
     expect(find.text("Map: 0"), findsOneWidget);
     expect(find.text("Obx: 0"), findsOneWidget);
 
-    Controller.to!.increment();
+    Controller.to.increment();
 
     await tester.pump();
 
@@ -52,7 +52,7 @@ void main() {
 }
 
 class Controller extends GetxController {
-  static Controller? get to => Get.find();
+  static Controller get to => Get.find();
 
   RxInt counter = 0.obs;
   RxDouble doubleNum = 0.0.obs;

--- a/test/state_manager/get_rxstate_test.dart
+++ b/test/state_manager/get_rxstate_test.dart
@@ -57,7 +57,7 @@ void main() {
     expect(find.text("List: 0"), findsOneWidget);
     expect(find.text("Map: 0"), findsOneWidget);
 
-    Controller.to!.increment();
+    Controller.to.increment();
 
     await tester.pump();
 
@@ -82,7 +82,7 @@ class ControllerNonGlobal extends GetxController {
 }
 
 class Controller extends GetxController {
-  static Controller? get to => Get.find();
+  static Controller get to => Get.find();
 
   RxInt counter = 0.obs;
   RxDouble doubleNum = 0.0.obs;

--- a/test/state_manager/get_state_test.dart
+++ b/test/state_manager/get_state_test.dart
@@ -47,7 +47,7 @@ void main() {
 
     expect(find.text("0"), findsOneWidget);
 
-    Controller.to!.increment();
+    Controller.to.increment();
 
     await test.pump();
 
@@ -83,7 +83,7 @@ void main() {
 }
 
 class Controller extends GetxController {
-  static Controller? get to => Get.find();
+  static Controller get to => Get.find();
 
   int counter = 0;
 


### PR DESCRIPTION
- I did a sequence of tests and it was possible to make `Get.put`, `Get.putAsync` and `Get.find` as **non-nullable**.
- I modified the test files to treat the above methods as non-nullable

Fixes #1156 