### PR TITLE
Return with effective_dart and fix typos

### DIFF
--- a/example/lib/lang/translation_service.dart
+++ b/example/lib/lang/translation_service.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-import 'en_US.dart';
-import 'pt_BR.dart';
+import 'en_us.dart';
+import 'pt_br.dart';
 
 class TranslationService extends Translations {
   static Locale get locale => Get.deviceLocale!;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'lang/translation_service.dart';

--- a/lib/get_connect/http/src/http/html/http_request_html.dart
+++ b/lib/get_connect/http/src/http/html/http_request_html.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:html' as html;
-import 'dart:typed_data';
 
 import '../../certificates/certificates.dart';
 import '../../exceptions/exceptions.dart';

--- a/lib/get_connect/http/src/multipart/form_data.dart
+++ b/lib/get_connect/http/src/multipart/form_data.dart
@@ -107,7 +107,7 @@ class FormData {
     for (final file in files) {
       yield separator;
       yield utf8.encode(_fileHeader(file));
-      yield* file.value.stream! as Stream<List<int>>;
+      yield* file.value.stream!;
       yield line;
     }
     yield close;

--- a/lib/get_connect/http/src/utils/utils.dart
+++ b/lib/get_connect/http/src/utils/utils.dart
@@ -1,6 +1,4 @@
-import 'dart:async';
 import 'dart:convert';
-import '../request/request.dart';
 
 bool isTokenChar(int byte) {
   return byte > 31 && byte < 128 && !SEPARATOR_MAP[byte];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  effective_dart: ^1.3.1
  
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
- effective_dart launched the null safety version and it is interesting to put it back on GetX for contributors to maintain a standardized code.

- Fix typos: unnecessary imports and syntax correction