### PR TITLE
Controller improperly removed

### DIFF
--- a/lib/get_navigation/src/routes/default_route.dart
+++ b/lib/get_navigation/src/routes/default_route.dart
@@ -31,7 +31,8 @@ class GetPageRoute<T> extends PageRoute<T> {
     this.maintainState = true,
     bool fullscreenDialog = false,
     this.middlewares,
-  })  : reference = "$routeName: ${page.hashCode}",
+    // })  : reference = "$routeName: ${page.hashCode}",
+  })  : reference = "$routeName: ${settings?.hashCode ?? page.hashCode}",
         super(settings: settings, fullscreenDialog: fullscreenDialog);
 
   @override

--- a/lib/get_navigation/src/routes/default_route.dart
+++ b/lib/get_navigation/src/routes/default_route.dart
@@ -31,7 +31,6 @@ class GetPageRoute<T> extends PageRoute<T> {
     this.maintainState = true,
     bool fullscreenDialog = false,
     this.middlewares,
-    // })  : reference = "$routeName: ${page.hashCode}",
   })  : reference = "$routeName: ${settings?.hashCode ?? page.hashCode}",
         super(settings: settings, fullscreenDialog: fullscreenDialog);
 

--- a/lib/get_navigation/src/routes/observers/route_observer.dart
+++ b/lib/get_navigation/src/routes/observers/route_observer.dart
@@ -161,7 +161,7 @@ class GetObserver extends NavigatorObserver {
       value.isDialog = newRoute.isDialog;
     });
 
-    print('currentRoute.isDialog ${currentRoute.isDialog}');
+    // print('currentRoute.isDialog ${currentRoute.isDialog}');
 
     routing?.call(_routeSend);
   }

--- a/lib/get_navigation/src/routes/route_middleware.dart
+++ b/lib/get_navigation/src/routes/route_middleware.dart
@@ -187,6 +187,7 @@ class PageRedirect {
           )
         : GetPageRoute<T>(
             page: route!.page,
+            routeName: route!.name,
             parameter: route!.parameter,
             settings: RouteSettings(
                 name: settings.name, arguments: settings.arguments),


### PR DESCRIPTION
**Problem Description**
Using named routes, when navigating to a page that is already in the navigation stack and then popping this page, the controller is improperly removed. Another problem with less impact is that PageRedirect (always called) was missing the routeName property, so _routesKey stored `null: hashCode`.

**Example**
Navigation: `/home -> /login -> /home -> pop`
![image](https://user-images.githubusercontent.com/9120528/113142383-306cee80-9201-11eb-8af8-bbc4d66f40f5.png)

**_routesKey:**
![image](https://user-images.githubusercontent.com/9120528/113142788-b0935400-9201-11eb-98a6-b817ec4b196c.png)


**Solution**
`GetPageRoute` uses `page.hashCode` to individualize each page to which it is navigated, but in named routes the hashCode is defined in `GetPage` and not in navigation as in unnamed routes, so the hashCode was duplicated and this caused the controller to be destroyed when pop at the wrong time. To solve it I used the hashCode of RouteSettings, because it is always defined during navigation and the problem has been solved. It was necessary to place a ternary if RouteSettings is null, but only in tests this happens.

Fixes #1040
Fixes #895 

