### PR TITLE
[GetConnect] defaultDecoder can be null

### DIFF
--- a/lib/get_connect/http/src/http.dart
+++ b/lib/get_connect/http/src/http.dart
@@ -249,7 +249,7 @@ class GetHttpClient {
       method: 'get',
       url: uri,
       headers: headers,
-      decoder: decoder ?? (defaultDecoder as Decoder<T>),
+      decoder: decoder ?? (defaultDecoder as Decoder<T>?),
       contentLength: 0,
     ));
   }


### PR DESCRIPTION
Only in `_get(...)` the `defaultDecoder` is cast to `Decoder<T>`. Everywhere else, e.g. in `_request(...)`, it is correctly cast to `Decoder<T>?`.