### PR TITLE
RxInt and RxnInt: adjust operator + and -

### DIFF
--- a/lib/get_rx/src/rx_types/rx_core/rx_num.dart
+++ b/lib/get_rx/src/rx_types/rx_core/rx_num.dart
@@ -848,25 +848,41 @@ class RxnDouble extends Rx<double?> {
 
 class RxInt extends Rx<int> {
   RxInt(int initial) : super(initial);
-}
 
-class RxnInt extends Rx<int?> {
-  RxnInt([int? initial]) : super(initial);
-}
-
-extension RxIntExt on Rx<int> {
   /// Addition operator.
-  Rx<int> operator +(int other) {
+  RxInt operator +(int other) {
     value = value + other;
     return this;
   }
 
   /// Subtraction operator.
-  Rx<int> operator -(int other) {
+  RxInt operator -(int other) {
     value = value - other;
     return this;
   }
+}
 
+class RxnInt extends Rx<int?> {
+  RxnInt([int? initial]) : super(initial);
+
+  /// Addition operator.
+  RxnInt operator +(int other) {
+    if (value != null) {
+      value = value! + other;
+    }
+    return this;
+  }
+
+  /// Subtraction operator.
+  RxnInt operator -(int other) {
+    if (value != null) {
+      value = value! - other;
+    }
+    return this;
+  }
+}
+
+extension RxIntExt on Rx<int> {
   /// Bit-wise and operator.
   ///
   /// Treating both `this` and [other] as sufficiently large two's component
@@ -1076,22 +1092,6 @@ extension RxIntExt on Rx<int> {
 }
 
 extension RxnIntExt on Rx<int?> {
-  /// Addition operator.
-  Rx<int?>? operator +(int other) {
-    if (value != null) {
-      value = value! + other;
-      return this;
-    }
-  }
-
-  /// Subtraction operator.
-  Rx<int?>? operator -(int other) {
-    if (value != null) {
-      value = value! - other;
-      return this;
-    }
-  }
-
   /// Bit-wise and operator.
   ///
   /// Treating both `this` and [other] as sufficiently large two's component


### PR DESCRIPTION
The `+` and `-` operators could not be used in RxInt and RxnInt, as it had an error. Example:

```dart
class Counter extends GetxController {
  var count = 0.obs;
  increment() => count++;
}
```
Erro: A value of type Rx<int> can't be assigned to a variable of type RxInt.

Fixes #1282 