### PR TITLE
Construct request with body for form-urlencoded.

### DIFF
--- a/lib/get_connect/http/src/http.dart
+++ b/lib/get_connect/http/src/http.dart
@@ -103,18 +103,20 @@ class GetHttpClient {
       headers['content-length'] = bodyBytes.length.toString();
       headers['content-type'] =
           'multipart/form-data; boundary=${body.boundary}';
+    } else if (contentType != null && contentType.toLowerCase() == 'application/x-www-form-urlencoded' && body is Map) {
+      var parts = [];
+      (body as Map<String, dynamic>).forEach((key, value) {
+        parts.add('${Uri.encodeQueryComponent(key)}='
+            '${Uri.encodeQueryComponent(value.toString())}');
+      });
+      var formData = parts.join('&');
+      bodyBytes = utf8.encode(formData);
     } else if (body is Map || body is List) {
       var jsonString = json.encode(body);
 
       bodyBytes = utf8.encode(jsonString);
       headers['content-length'] = bodyBytes.length.toString();
       headers['content-type'] = contentType ?? defaultContentType;
-      //TODO check this implementation
-      if (contentType != null) {
-        if (contentType.toLowerCase() == 'application/x-www-form-urlencoded') {
-          jsonString = Uri.encodeQueryComponent(jsonString);
-        }
-      }
     } else if (body is String) {
       bodyBytes = utf8.encode(body);
       headers['content-length'] = bodyBytes.length.toString();


### PR DESCRIPTION
I am unable to make a post request with `contentType: 'application/x-www-form-urlencoded'` using GetConnect.
```dart
class AuthenticationProvider extends BaseProvider { // This just adds some headers.
  static const String _tokenEndpoint = 'Token';

  @override
  void onInit() {
    super.onInit();

    httpClient.defaultDecoder = (val) => TokenDto.fromJson(val);
  }

  // This request fails, because sent body is invalid for given content type.
  Future<Response<TokenDto>> getToken(SignInWithPasswordDto payload) => post(
        _tokenEndpoint,
        payload.toJson(),
        contentType: 'application/x-www-form-urlencoded',
        headers: {'Authorization': getConnectionConfig().authorization},
      );
}
```

So, the problem is in body constructing. Body should be constructed as a url string and not json.