### PR TITLE
Set darkThem equal theme when darkTheme is null

### DIFF
--- a/lib/get_navigation/src/root/get_material_app.dart
+++ b/lib/get_navigation/src/root/get_material_app.dart
@@ -245,7 +245,8 @@ class GetMaterialApp extends StatelessWidget {
               onGenerateTitle: onGenerateTitle,
               color: color,
               theme: _.theme ?? theme ?? ThemeData.fallback(),
-              darkTheme: _.darkTheme ?? darkTheme ?? ThemeData.fallback(),
+              darkTheme:
+                  _.darkTheme ?? darkTheme ?? theme ?? ThemeData.fallback(),
               themeMode: _.themeMode ?? themeMode,
               locale: Get.locale ?? locale,
               localizationsDelegates: localizationsDelegates,
@@ -293,7 +294,8 @@ class GetMaterialApp extends StatelessWidget {
               onGenerateTitle: onGenerateTitle,
               color: color,
               theme: _.theme ?? theme ?? ThemeData.fallback(),
-              darkTheme: _.darkTheme ?? darkTheme ?? ThemeData.fallback(),
+              darkTheme:
+                  _.darkTheme ?? darkTheme ?? theme ?? ThemeData.fallback(),
               themeMode: _.themeMode ?? themeMode,
               locale: Get.locale ?? locale,
               localizationsDelegates: localizationsDelegates,


### PR DESCRIPTION
In GetMaterialApp, when theme was defined and darkTheme was not and the device / simulator is in dark mode, the theme configuration was not respected, breaking the layout.

Fixes #1291 
Fixes #1290 
Fixes #1281
