### PR TITLE
Make withCredentials configurable

### DIFF
--- a/lib/get_connect/connect.dart
+++ b/lib/get_connect/connect.dart
@@ -97,6 +97,7 @@ class GetConnect extends GetConnectInterface {
     this.maxRedirects = 5,
     this.maxAuthRetries = 1,
     this.allowAutoSignedCert = false,
+    this.withCredentials = false,
   }) {
     $configureLifeCycle();
   }
@@ -113,6 +114,7 @@ class GetConnect extends GetConnectInterface {
   List<TrustedCertificate>? trustedCertificates;
   GetHttpClient? _httpClient;
   List<GetSocket>? _sockets;
+  bool withCredentials;
 
   @override
   List<GetSocket> get sockets => _sockets ??= <GetSocket>[];
@@ -127,6 +129,7 @@ class GetConnect extends GetConnectInterface {
         allowAutoSignedCert: allowAutoSignedCert,
         baseUrl: baseUrl,
         trustedCertificates: trustedCertificates,
+        withCredentials: withCredentials,
       );
 
   @override

--- a/lib/get_connect/http/src/http.dart
+++ b/lib/get_connect/http/src/http.dart
@@ -46,9 +46,11 @@ class GetHttpClient {
     bool allowAutoSignedCert = false,
     this.baseUrl,
     List<TrustedCertificate>? trustedCertificates,
+    bool withCredentials = false,
   })  : _httpClient = HttpRequestImpl(
           allowAutoSignedCert: allowAutoSignedCert,
           trustedCertificates: trustedCertificates,
+          withCredentials: withCredentials,
         ),
         _modifier = GetModifier();
 

--- a/lib/get_connect/http/src/http/html/http_request_html.dart
+++ b/lib/get_connect/http/src/http/html/http_request_html.dart
@@ -13,6 +13,7 @@ class HttpRequestImpl implements HttpRequestBase {
   HttpRequestImpl({
     bool allowAutoSignedCert = true,
     List<TrustedCertificate>? trustedCertificates,
+    this.withCredentials = false,
   });
 
   /// The currently active XHRs.
@@ -20,7 +21,7 @@ class HttpRequestImpl implements HttpRequestBase {
 
   ///This option requires that you submit credentials for requests
   ///on different sites. The default is false
-  bool withCredentials = false;
+  final bool withCredentials;
 
   /// Sends an HTTP request and asynchronously returns the response.
   @override

--- a/lib/get_connect/http/src/http/io/http_request_io.dart
+++ b/lib/get_connect/http/src/http/io/http_request_io.dart
@@ -16,6 +16,7 @@ class HttpRequestImpl extends HttpRequestBase {
   HttpRequestImpl({
     bool allowAutoSignedCert = true,
     List<TrustedCertificate>? trustedCertificates,
+    bool withCredentials = false,
   }) {
     _httpClient = io.HttpClient();
     if (trustedCertificates != null) {

--- a/lib/get_connect/http/src/http/stub/http_request_stub.dart
+++ b/lib/get_connect/http/src/http/stub/http_request_stub.dart
@@ -7,6 +7,7 @@ class HttpRequestImpl extends HttpRequestBase {
   HttpRequestImpl({
     bool allowAutoSignedCert = true,
     List<TrustedCertificate>? trustedCertificates,
+    bool withCredentials = false,
   });
   @override
   void close() {}


### PR DESCRIPTION
In order for cookie to work for flutter web, we need to set the withCredentials = true.