### PR TITLE
Add content type and length into the headers when the content type is 'application/x-www-form-urlencoded'

### DIFF
--- a/lib/get_connect/http/src/http.dart
+++ b/lib/get_connect/http/src/http.dart
@@ -113,6 +113,8 @@ class GetHttpClient {
       });
       var formData = parts.join('&');
       bodyBytes = utf8.encode(formData);
+      headers['content-length'] = bodyBytes.length.toString();
+      headers['content-type'] = contentType;
     } else if (body is Map || body is List) {
       var jsonString = json.encode(body);
 


### PR DESCRIPTION
Add 'content-type' & 'content-length' into the headers when the content type is 'application/x-www-form-urlencoded'