### PR TITLE
Bug fixed: Redundant concatenating base url

### DIFF
--- a/lib/get_connect/connect.dart
+++ b/lib/get_connect/connect.dart
@@ -303,7 +303,7 @@ class GetConnect extends GetConnectInterface {
   }) async {
     try {
       final res = await post(
-        _concatUrl(url),
+        url,
         {'query': query, 'variables': variables},
         headers: headers,
       );
@@ -339,7 +339,7 @@ class GetConnect extends GetConnectInterface {
   }) async {
     try {
       final res = await post(
-        _concatUrl(url),
+        url,
         {'query': mutation, 'variables': variables},
         headers: headers,
       );


### PR DESCRIPTION
Concatenating url with base url will be done inside _requestWithBody method. Removing from here as it is redundant.