### PR TITLE
GraphQLResponse inherit Response info

### DIFF
--- a/lib/get_connect/connect.dart
+++ b/lib/get_connect/connect.dart
@@ -319,7 +319,7 @@ class GetConnect extends GetConnectInterface {
                     ))
                 .toList());
       }
-      return GraphQLResponse<T>(body: res.body['data'] as T?);
+      return GraphQLResponse<T>.fromResponse(res);
     } on Exception catch (_) {
       return GraphQLResponse<T>(graphQLErrors: [
         GraphQLError(
@@ -355,7 +355,7 @@ class GetConnect extends GetConnectInterface {
                     ))
                 .toList());
       }
-      return GraphQLResponse<T>(body: res.body['data'] as T?);
+      return GraphQLResponse<T>.fromResponse(res);
     } on Exception catch (_) {
       return GraphQLResponse<T>(graphQLErrors: [
         GraphQLError(

--- a/lib/get_connect/http/src/response/response.dart
+++ b/lib/get_connect/http/src/response/response.dart
@@ -7,6 +7,16 @@ import '../status/http_status.dart';
 class GraphQLResponse<T> extends Response<T> {
   final List<GraphQLError>? graphQLErrors;
   GraphQLResponse({T? body, this.graphQLErrors}) : super(body: body);
+  GraphQLResponse.fromResponse(Response res)
+      : graphQLErrors = null,
+        super(
+            request: res.request,
+            statusCode: res.statusCode,
+            bodyBytes: res.bodyBytes,
+            bodyString: res.bodyString,
+            statusText: res.statusText,
+            headers: res.headers,
+            body: res.body['data'] as T?);
 }
 
 class Response<T> {
@@ -60,7 +70,8 @@ class Response<T> {
   final T? body;
 }
 
-Future<String> bodyBytesToString(Stream<List<int>> bodyBytes, Map<String, String> headers) {
+Future<String> bodyBytesToString(
+    Stream<List<int>> bodyBytes, Map<String, String> headers) {
   return bodyBytes.bytesToString(_encodingForHeaders(headers));
 }
 
@@ -101,7 +112,9 @@ class HeaderValue {
   }
 
   static HeaderValue parse(String value,
-      {String parameterSeparator = ';', String? valueSeparator, bool preserveBackslash = false}) {
+      {String parameterSeparator = ';',
+      String? valueSeparator,
+      bool preserveBackslash = false}) {
     var result = HeaderValue();
     result._parse(value, parameterSeparator, valueSeparator, preserveBackslash);
     return result;
@@ -131,7 +144,8 @@ class HeaderValue {
     return stringBuffer.toString();
   }
 
-  void _parse(String value, String parameterSeparator, String? valueSeparator, bool preserveBackslash) {
+  void _parse(String value, String parameterSeparator, String? valueSeparator,
+      bool preserveBackslash) {
     var index = 0;
 
     bool done() => index == value.length;


### PR DESCRIPTION
After a successful graphql call, the GraphQLResponse, which is inherited from Response, does not contains all the info, except body, from the query/mutation response. This makes all the current attributes such as hasError, isOk are not usable.

Fixed to fill up the response information when transforming to GraphQLResponse.