### PR TITLE
Allow deleting all registered instances

### DIFF
--- a/lib/get_instance/src/extension_instance.dart
+++ b/lib/get_instance/src/extension_instance.dart
@@ -109,6 +109,13 @@ extension Inst on GetInterface {
   Future<bool> delete<S>({String? tag, bool force = false}) async =>
       GetInstance().delete<S>(tag: tag, force: force);
 
+  /// Deletes all Instances, cleaning the memory and closes any open
+  /// controllers ([DisposableInterface]).
+  /// 
+  /// - [force] Will delete the Instances even if marked as [permanent].
+  Future<void> deleteAll({bool force = false}) async =>
+      GetInstance().deleteAll(force: force);
+
   void reloadAll({bool force = false}) => GetInstance().reloadAll(force: force);
 
   void reload<S>({String? tag, String? key, bool force = false}) =>

--- a/lib/get_instance/src/get_instance.dart
+++ b/lib/get_instance/src/get_instance.dart
@@ -96,7 +96,10 @@ class GetInstance {
     @deprecated InstanceBuilderCallback<S>? builder,
   }) {
     _insert(
-        isSingleton: true, name: tag, permanent: permanent, builder: builder ?? (() => dependency));
+        isSingleton: true,
+        name: tag,
+        permanent: permanent,
+        builder: builder ?? (() => dependency));
     return find<S>(tag: tag);
   }
 

--- a/lib/get_instance/src/get_instance.dart
+++ b/lib/get_instance/src/get_instance.dart
@@ -96,10 +96,7 @@ class GetInstance {
     @deprecated InstanceBuilderCallback<S>? builder,
   }) {
     _insert(
-        isSingleton: true,
-        name: tag,
-        permanent: permanent,
-        builder: builder ?? (() => dependency));
+        isSingleton: true, name: tag, permanent: permanent, builder: builder ?? (() => dependency));
     return find<S>(tag: tag);
   }
 
@@ -412,6 +409,16 @@ class GetInstance {
     }
 
     return true;
+  }
+
+  /// Delete all registered Class Instances and, closes any open
+  /// controllers [DisposableInterface], cleans up the memory
+  ///
+  /// - [force] Will delete the Instances even if marked as [permanent].
+  void deleteAll({bool force = false}) {
+    _singl.forEach((key, value) {
+      delete(key: key, force: force);
+    });
   }
 
   void reloadAll({bool force = false}) {


### PR DESCRIPTION
In our project we're using permanent Controllers to manage some of the applications state.

It works very well but after logout we want to reset them by reinitialisation.

Currently we have to call delete on the same ones we initialised one-by-one and this approach is prone to mistakes.

We could however use a method that deletes all the controllers from memory.


```
    Get.put(A(), permanent: true);
    Get.put(B(), permanent: true);
    Get.put(C(), permanent: true);
    
    ///
    
    Get.delete<A>(force: true);
    Get.delete<B>(force: true);
    Get.delete<C>(force: true);
```

->

```
    Get.put(A(), permanent: true);
    Get.put(B(), permanent: true);
    Get.put(C(), permanent: true);
    
    ///
    
    Get.deleteAll();
```