### PR TITLE
Programmatically remove GetBar

### DIFF
--- a/lib/get_navigation/src/extension_navigation.dart
+++ b/lib/get_navigation/src/extension_navigation.dart
@@ -102,6 +102,14 @@ extension ExtensionSnackbar on GetInterface {
     return key.currentState?.push(SnackRoute<T>(snack: snackbar));
   }
 
+  /// Returns a snackbar with it's callback to be removed from stack
+  /// 
+  /// The return is a list `[VoidCallback, Future<T?>?]`
+  List<dynamic> showSnackBarWithRemoveCallback<T>(GetBar snackbar) {
+    var route = SnackRoute<T>(snack: snackbar);
+    return [route.remove, key.currentState?.push(route)];
+  }
+
   void snackbar<T>(
     String title,
     String message, {
@@ -449,8 +457,10 @@ extension ExtensionBottomSheet on GetInterface {
       modalBarrierColor: barrierColor,
       settings: settings,
       enableDrag: enableDrag,
-      enterBottomSheetDuration: enterBottomSheetDuration ?? const Duration(milliseconds: 250),
-      exitBottomSheetDuration: exitBottomSheetDuration ?? const Duration(milliseconds: 200),
+      enterBottomSheetDuration:
+          enterBottomSheetDuration ?? const Duration(milliseconds: 250),
+      exitBottomSheetDuration:
+          exitBottomSheetDuration ?? const Duration(milliseconds: 200),
     ));
   }
 }

--- a/lib/get_navigation/src/snackbar/snack_route.dart
+++ b/lib/get_navigation/src/snackbar/snack_route.dart
@@ -184,6 +184,16 @@ class SnackRoute<T> extends OverlayRoute<T> {
     );
   }
 
+  /// Just waits until the animationControllerStatus is completed and
+  /// removes the overlayEntry
+  Future<void> remove() async {
+    await Future.doWhile(() async {
+      await Future.delayed(Duration(milliseconds: 50));
+      return _controller!.status != AnimationStatus.completed;
+    });
+    _controller!.reverse();
+  }
+
   /// Called to create the animation that exposes the current progress of
   /// the transition controlled by the animation controller created by
   /// [createAnimationController()].


### PR DESCRIPTION
`showSnackBarWithRemoveCallback(GetBar)` returns a `VoidCallback` item to programmatically close a snack bar after it has been shown

Related issue: #1547