### PR TITLE
Add GetBindWidget

### DIFF
--- a/lib/get_state_manager/get_state_manager.dart
+++ b/lib/get_state_manager/get_state_manager.dart
@@ -5,6 +5,7 @@ export 'src/rx_flutter/rx_getx_widget.dart';
 export 'src/rx_flutter/rx_notifier.dart';
 export 'src/rx_flutter/rx_obx_widget.dart';
 export 'src/rx_flutter/rx_ticket_provider_mixin.dart';
+export 'src/simple/get_bind_widget.dart';
 export 'src/simple/get_controllers.dart';
 export 'src/simple/get_responsive.dart';
 export 'src/simple/get_state.dart';

--- a/lib/get_state_manager/src/simple/get_bind_widget.dart
+++ b/lib/get_state_manager/src/simple/get_bind_widget.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/widgets.dart';
+
+import '../../../instance_manager.dart';
+import 'get_controllers.dart';
+
+/// GetBindWidget can bind GetxController, and when the page is disposed,
+/// it can automatically destroy the bound related GetXController
+///
+///
+/// Sample:
+///
+/// class SampleController extends GetxController {
+///   final String title = 'My Awesome View';
+/// }
+///
+/// class SamplePage extends StatelessWidget {
+///   final controller = SampleController();
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return GetBindWidget(
+///       bind: controller,
+///       child: Container(),
+///     );
+///   }
+/// }
+class GetBindWidget extends StatefulWidget {
+  const GetBindWidget({
+    Key? key,
+    this.bind,
+    this.tag,
+    this.binds,
+    this.tags,
+    required this.child,
+  })   : assert(
+          binds == null || tags == null || binds.length == tags.length,
+          'The binds and tags arrays length should be equal\n'
+          'and the elements in the two arrays correspond one-to-one',
+        ),
+        super(key: key);
+
+  final GetxController? bind;
+  final String? tag;
+
+  final List<GetxController>? binds;
+  final List<String>? tags;
+
+  final Widget child;
+
+  @override
+  _GetBindWidgetState createState() => _GetBindWidgetState();
+}
+
+class _GetBindWidgetState extends State<GetBindWidget> {
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+
+  @override
+  void dispose() {
+    _closeGetXController();
+    _closeGetXControllers();
+
+    super.dispose();
+  }
+
+  ///Close GetxController bound to the current page
+  void _closeGetXController() {
+    if (widget.bind == null) {
+      return;
+    }
+
+    var key = widget.bind.runtimeType.toString() + (widget.tag ?? '');
+    GetInstance().delete(key: key);
+  }
+
+  ///Batch close GetxController bound to the current page
+  void _closeGetXControllers() {
+    if (widget.binds == null) {
+      return;
+    }
+
+    for (var i = 0; i < widget.binds!.length; i++) {
+      var type = widget.binds![i].runtimeType.toString();
+
+      if (widget.tags == null) {
+        GetInstance().delete(key: type);
+      } else {
+        var key = type + (widget.tags?[i] ?? '');
+        GetInstance().delete(key: key);
+      }
+    }
+  }
+}


### PR DESCRIPTION
> **I found that GetxController is automatically destroyed in the page and needs to cooperate with Getx's routing management. If you use system routing, GetxController cannot be recycled.**
>
> **example**

- jump

```dart
Navigator.push(
    Get.context,
    MaterialPageRoute(builder: (context) => SamplePage()),
);
```

- GetxController

```dart
class SampleController extends GetxController {
  var count = 0.obs;

  void increase() => ++count;
}
```

- page

```dart
class SamplePage extends StatelessWidget {
  final SampleController controller = Get.put(SampleController());

  @override
  Widget build(BuildContext context) {
    return BaseScaffold(
      appBar: AppBar(title: const Text('Simple')),
      body: Center(
        child: Obx(() {
          return Text(
            'Count ${controller.count.value} ',
            style: TextStyle(fontSize: 30.0),
          );
        }),
      ),
      floatingActionButton: FloatingActionButton(
        onPressed: () => controller.increase(),
        child: Icon(Icons.add),
      ),
    );
  }
}
```

- I had to use StatefulWidget to solve this problem

```dart
class SamplePage extends StatefulWidget {
  const SamplePage({Key? key}) : super(key: key);

  @override
  _SamplePageState createState() => _SamplePageState();
}

class _SamplePageState extends State<SamplePage> {
  final SampleController controller = Get.put(SampleController());
  
  @override
  Widget build(BuildContext context) {
    return BaseScaffold(
      appBar: AppBar(title: const Text('Simple')),
      body: Center(
        child: Obx(() {
          return Text(
            'Count ${controller.count.value} ',
            style: TextStyle(fontSize: 30.0),
          );
        }),
      ),
      floatingActionButton: FloatingActionButton(
        onPressed: () => controller.increase(),
        child: Icon(Icons.add),
      ),
    );
  }

  @override
  void dispose() {
    Get.delete<SampleController>();
    super.dispose();
  }
}
```

> However, using StatefulWidget makes the page look a bit complicated, so I customize **GetBindWidget**, which can easily solve this problem

- GetBindWidget

```dart
class SamplePage extends StatelessWidget {
  final SampleController controller = Get.put(SampleController());

  @override
  Widget build(BuildContext context) {
    return GetBindWidget(
      bind: controller,
      child: BaseScaffold(
        appBar: AppBar(title: const Text('Simple')),
        body: Center(
          child: Obx(() {
            return Text(
              'Count ${controller.count.value} ',
              style: TextStyle(fontSize: 30.0),
            );
          }),
        ),
        floatingActionButton: FloatingActionButton(
          onPressed: () => controller.increase(),
          child: Icon(Icons.add),
        ),
      ),
    );
  }
}
```

- this is the code of **GetBindWidget**, I hope to pass this PR

```dart
class GetBindWidget extends StatefulWidget {
  const GetBindWidget({
    Key? key,
    this.bind,
    this.tag,
    this.binds,
    this.tags,
    required this.child,
  })   : assert(
          binds == null || tags == null || binds.length == tags.length,
          'The binds and tags arrays length should be equal\n'
          'and the elements in the two arrays correspond one-to-one',
        ),
        super(key: key);

  final GetxController? bind;
  final String? tag;

  final List<GetxController>? binds;
  final List<String>? tags;

  final Widget child;

  @override
  _GetBindWidgetState createState() => _GetBindWidgetState();
}

class _GetBindWidgetState extends State<GetBindWidget> {
  @override
  Widget build(BuildContext context) {
    return widget.child;
  }

  @override
  void dispose() {
    _closeGetXController();
    _closeGetXControllers();

    super.dispose();
  }

  ///Close GetxController bound to the current page
  void _closeGetXController() {
    if (widget.bind == null) {
      return;
    }

    var key = widget.bind.runtimeType.toString() + (widget.tag ?? '');
    GetInstance().delete(key: key);
  }

  ///Batch close GetxController bound to the current page
  void _closeGetXControllers() {
    if (widget.binds == null) {
      return;
    }

    for (var i = 0; i < widget.binds!.length; i++) {
      var type = widget.binds![i].runtimeType.toString();

      if (widget.tags == null) {
        GetInstance().delete(key: type);
      } else {
        var key = type + (widget.tags?[i] ?? '');
        GetInstance().delete(key: key);
      }
    }
  }
}
```

