### PR TITLE
(fix) import error in example

### DIFF
--- a/example/lib/lang/translation_service.dart
+++ b/example/lib/lang/translation_service.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-import 'en_us.dart';
-import 'pt_br.dart';
+import 'en_US.dart';
+import 'pt_BR.dart';
 
 class TranslationService extends Translations {
   static Locale? get locale => Get.deviceLocale;


### PR DESCRIPTION
There was a import error in example, transaltion_service.dart file. This pull request fixes those errors.