### PR TITLE
Added dispose() for bottomSheet.

### DIFF
--- a/lib/get_navigation/src/bottomsheet/bottomsheet.dart
+++ b/lib/get_navigation/src/bottomsheet/bottomsheet.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import '../../../get_core/get_core.dart';
+import '../../../get_instance/src/get_instance.dart';
 
 class GetModalBottomSheetRoute<T> extends PopupRoute<T> {
   GetModalBottomSheetRoute({
@@ -50,6 +52,15 @@ class GetModalBottomSheetRoute<T> extends PopupRoute<T> {
   Color get barrierColor => modalBarrierColor ?? Colors.black54;
 
   AnimationController? _animationController;
+
+  @override
+  void dispose() {
+    if (Get.smartManagement != SmartManagement.onlyBuilder) {
+      WidgetsBinding.instance!.addPostFrameCallback(
+          (_) => GetInstance().removeDependencyByRoute(name));
+    }
+    super.dispose();
+  }
 
   @override
   AnimationController createAnimationController() {


### PR DESCRIPTION
*BottomSheet haven't dispose() method. I added this method for dispose of the BottomSheet with its controller (Like Dialog).*

```
  @override
  void dispose() {
    if (Get.smartManagement != SmartManagement.onlyBuilder) {
      WidgetsBinding.instance!.addPostFrameCallback(
          (_) => GetInstance().removeDependencyByRoute(name)); // name = "BOTTOMSHEET: ${builder.hashCode}";
    }
    super.dispose();
  }
```

- Fixes #1127 
- Fixes #1351 

## Pre-launch Checklist

- [-] I updated/added relevant documentation (doc comments with `///`).
- [-] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [✓] All existing and new tests are passing.
