### PR TITLE
A RxObject should be == self

### DIFF
--- a/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
+++ b/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
@@ -82,9 +82,9 @@ mixin RxObjectMixin<T> on NotifyManager<T> {
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object o) {
+    if (o is RxObjectMixin<T>) return value == o.value;
     // Todo, find a common implementation for the hashCode of different Types.
     if (o is T) return value == o;
-    if (o is RxObjectMixin<T>) return value == o.value;
     return false;
   }
 

--- a/test/rx/rx_workers_test.dart
+++ b/test/rx/rx_workers_test.dart
@@ -162,4 +162,9 @@ void main() {
     expect(reactiveString.endsWith("c"), true);
     expect(currentString, "abc");
   });
+
+  test('Rx List ==', () {
+    final list = RxList();
+    expect(list == list, true);
+  });
 }


### PR DESCRIPTION
For now, a RxList is not equal to itself.