### PR TITLE
Fix RxInterface.proxy losing its previous value on exception

### DIFF
--- a/lib/get_rx/src/rx_types/rx_core/rx_interface.dart
+++ b/lib/get_rx/src/rx_types/rx_core/rx_interface.dart
@@ -25,6 +25,7 @@ abstract class RxInterface<T> {
     RxInterface.proxy = observer;
     final result = builder();
     if (!observer.canUpdate) {
+      RxInterface.proxy = _observer;
       throw """
       [Get] the improper use of a GetX has been detected. 
       You should only use GetX or Obx for the specific widget that will be updated.


### PR DESCRIPTION
Currently, whenever we encounter the `!canUpdate` exception, the static `RxInterface.proxy` isn't reverted to its previous value, making it really unsafe for other `Obx`/`Rx` (I personally encountered a problem where an `Obx` doesn't listen correctly to its `.obs`'s if there was an exception).

And yes I see that this exception should be avoided in the first place, but still, this is much safer imho.

## Pre-launch Checklist

- [-] I updated/added relevant documentation (doc comments with `///`).
- [-] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [v] All existing and new tests are passing.
