### PR TITLE
add replace method to specify alternate instance

### DIFF
--- a/documentation/en_US/dependency_management.md
+++ b/documentation/en_US/dependency_management.md
@@ -6,12 +6,13 @@
     - [Get.putAsync](#getputasync)
     - [Get.create](#getcreate)
   - [Using instantiated methods/classes](#using-instantiated-methodsclasses)
+  - [Specifying an alternate instance](#specifying-an-alternate-instance)
   - [Differences between methods](#differences-between-methods)
   - [Bindings](#bindings)
-    - [How to use](#how-to-use)
+    - [Bindings class](#bindings-class)
     - [BindingsBuilder](#bindingsbuilder)
     - [SmartManagement](#smartmanagement)
-      - [How to change](#How-to-change)
+      - [How to change](#how-to-change)
       - [SmartManagement.full](#smartmanagementfull)
       - [SmartManagement.onlyBuilders](#smartmanagementonlybuilders)
       - [SmartManagement.keepFactory](#smartmanagementkeepfactory)
@@ -200,6 +201,25 @@ To remove an instance of Get:
 
 ```dart
 Get.delete<Controller>(); //usually you don't need to do this because GetX already delete unused controllers
+```
+
+## Specifying an alternate instance
+
+A currently inserted instance can be replaced with a similar or extended class instance by using the `replace` method. This can then be retrieved by using the original class.
+
+```dart
+class ParentClass {}
+
+class ChildClass extends ParentClass {
+  bool isChild = true;
+}
+
+Get.put(ParentClass());
+
+Get.replace<ParentClass, ChildClass>(ChildClass());
+
+final instance = Get.find<ParentClass>();
+print(instance is ChildClass); //true
 ```
 
 ## Differences between methods

--- a/lib/get_instance/src/extension_instance.dart
+++ b/lib/get_instance/src/extension_instance.dart
@@ -136,8 +136,7 @@ extension Inst on GetInterface {
     final info = GetInstance().getInstanceInfo<P>(tag: tag);
     final permanent = (info.isPermanent ?? false);
     delete<P>(tag: tag, force: permanent);
-    // ignore: unnecessary_cast
-    put(child as P, tag: tag, permanent: permanent);
+    put(child, tag: tag, permanent: permanent);
   }
 
   /// Replaces a parent instance with a new Instance<P> lazily from the

--- a/lib/get_instance/src/extension_instance.dart
+++ b/lib/get_instance/src/extension_instance.dart
@@ -139,4 +139,19 @@ extension Inst on GetInterface {
     // ignore: unnecessary_cast
     put(child as P, tag: tag, permanent: permanent);
   }
+
+  /// Replaces a parent instance with a new Instance<P> lazily from the
+  /// [<P>builder()] callback.
+  /// - [tag] optional, if you use a [tag] to register the Instance.
+  /// - [fenix] optional
+  ///
+  ///  Note: if fenix is not provided it will be set to true if
+  /// the parent instance was permanent
+  void lazyReplace<P>(InstanceBuilderCallback<P> builder,
+      {String? tag, bool? fenix}) {
+    final info = GetInstance().getInstanceInfo<P>(tag: tag);
+    final permanent = (info.isPermanent ?? false);
+    delete<P>(tag: tag, force: permanent);
+    lazyPut(builder, tag: tag, fenix: fenix ?? permanent);
+  }
 }

--- a/lib/get_instance/src/extension_instance.dart
+++ b/lib/get_instance/src/extension_instance.dart
@@ -128,4 +128,12 @@ extension Inst on GetInterface {
   /// [Get.lazyPut()], is registered in memory.
   /// - [tag] optional, if you use a [tag] to register the Instance.
   bool isPrepared<S>({String? tag}) => GetInstance().isPrepared<S>(tag: tag);
+
+  /// Replace a parent instance of a class in dependency management
+  /// with a [child] instance
+  void replace<P, C extends P>(C child, {String? tag, bool permanent = false}) {
+    delete<P>();
+    // ignore: unnecessary_cast
+    put(child as P, tag: tag, permanent: permanent);
+  }
 }

--- a/lib/get_instance/src/extension_instance.dart
+++ b/lib/get_instance/src/extension_instance.dart
@@ -131,8 +131,11 @@ extension Inst on GetInterface {
 
   /// Replace a parent instance of a class in dependency management
   /// with a [child] instance
-  void replace<P, C extends P>(C child, {String? tag, bool permanent = false}) {
-    delete<P>();
+  /// - [tag] optional, if you use a [tag] to register the Instance.
+  void replace<P, C extends P>(C child, {String? tag}) {
+    final info = GetInstance().getInstanceInfo<P>(tag: tag);
+    final permanent = (info.isPermanent ?? false);
+    delete<P>(tag: tag, force: permanent);
     // ignore: unnecessary_cast
     put(child as P, tag: tag, permanent: permanent);
   }

--- a/lib/get_instance/src/extension_instance.dart
+++ b/lib/get_instance/src/extension_instance.dart
@@ -132,7 +132,7 @@ extension Inst on GetInterface {
   /// Replace a parent instance of a class in dependency management
   /// with a [child] instance
   /// - [tag] optional, if you use a [tag] to register the Instance.
-  void replace<P, C extends P>(C child, {String? tag}) {
+  void replace<P>(P child, {String? tag}) {
     final info = GetInstance().getInstanceInfo<P>(tag: tag);
     final permanent = (info.isPermanent ?? false);
     delete<P>(tag: tag, force: permanent);

--- a/test/instance/get_instance_test.dart
+++ b/test/instance/get_instance_test.dart
@@ -10,7 +10,9 @@ class Mock {
   }
 }
 
-class DisposableController extends GetLifeCycle {}
+abstract class MyController extends GetLifeCycle {}
+
+class DisposableController extends MyController {}
 
 // ignore: one_member_abstracts
 abstract class Service {
@@ -157,42 +159,49 @@ void main() {
     });
   });
 
-  test('Get.replace test for replacing temporary parent instance with child',
-      () async {
-    Get.put(DisposableController());
-    Get.replace<DisposableController, Controller>(Controller());
-    final instance = Get.find<DisposableController>();
-    expect(instance is Controller, isTrue);
-    expect((instance as Controller).init, greaterThan(0));
-  });
+  group('Get.replace test for replacing parent instance that is', () {
+    test('temporary', () async {
+      Get.put(DisposableController());
+      Get.replace<DisposableController>(Controller());
+      final instance = Get.find<DisposableController>();
+      expect(instance is Controller, isTrue);
+      expect((instance as Controller).init, greaterThan(0));
+    });
 
-  test('Get.replace test for replacing permanent parent instance with child',
-      () async {
-    Get.put(DisposableController(), permanent: true);
-    Get.replace<DisposableController, Controller>(Controller());
-    final instance = Get.find<DisposableController>();
-    expect(instance is Controller, isTrue);
-    expect((instance as Controller).init, greaterThan(0));
-  });
+    test('permanent', () async {
+      Get.put(DisposableController(), permanent: true);
+      Get.replace<DisposableController>(Controller());
+      final instance = Get.find<DisposableController>();
+      expect(instance is Controller, isTrue);
+      expect((instance as Controller).init, greaterThan(0));
+    });
 
-  test('Get.replace test for replacing tagged temporary instance with child',
-      () async {
-    final tag = 'tag';
-    Get.put(DisposableController(), tag: tag);
-    Get.replace<DisposableController, Controller>(Controller(), tag: tag);
-    final instance = Get.find<DisposableController>(tag: tag);
-    expect(instance is Controller, isTrue);
-    expect((instance as Controller).init, greaterThan(0));
-  });
+    test('tagged temporary', () async {
+      final tag = 'tag';
+      Get.put(DisposableController(), tag: tag);
+      Get.replace<DisposableController>(Controller(), tag: tag);
+      final instance = Get.find<DisposableController>(tag: tag);
+      expect(instance is Controller, isTrue);
+      expect((instance as Controller).init, greaterThan(0));
+    });
 
-  test('Get.replace test for replacing tagged parent instance with child',
-      () async {
-    final tag = 'tag';
-    Get.put(DisposableController(), permanent: true, tag: tag);
-    Get.replace<DisposableController, Controller>(Controller(), tag: tag);
-    final instance = Get.find<DisposableController>(tag: tag);
-    expect(instance is Controller, isTrue);
-    expect((instance as Controller).init, greaterThan(0));
+    test('tagged permanent', () async {
+      final tag = 'tag';
+      Get.put(DisposableController(), permanent: true, tag: tag);
+      Get.replace<DisposableController>(Controller(), tag: tag);
+      final instance = Get.find<DisposableController>(tag: tag);
+      expect(instance is Controller, isTrue);
+      expect((instance as Controller).init, greaterThan(0));
+    });
+
+    test('a generic parent type', () async {
+      final tag = 'tag';
+      Get.put<MyController>(DisposableController(), permanent: true, tag: tag);
+      Get.replace<MyController>(Controller(), tag: tag);
+      final instance = Get.find<MyController>(tag: tag);
+      expect(instance is Controller, isTrue);
+      expect((instance as Controller).init, greaterThan(0));
+    });
   });
 }
 

--- a/test/instance/get_instance_test.dart
+++ b/test/instance/get_instance_test.dart
@@ -160,6 +160,7 @@ void main() {
   });
 
   group('Get.replace test for replacing parent instance that is', () {
+    tearDown(Get.reset);
     test('temporary', () async {
       Get.put(DisposableController());
       Get.replace<DisposableController>(Controller());
@@ -201,6 +202,40 @@ void main() {
       final instance = Get.find<MyController>(tag: tag);
       expect(instance is Controller, isTrue);
       expect((instance as Controller).init, greaterThan(0));
+    });
+  });
+
+  group('Get.lazyReplace replaces parent instance', () {
+    tearDown(Get.reset);
+    test('without fenix', () async {
+      Get.put(DisposableController());
+      Get.lazyReplace<DisposableController>(() => Controller());
+      final instance = Get.find<DisposableController>();
+      expect(instance, isA<Controller>());
+      expect((instance as Controller).init, greaterThan(0));
+    });
+
+    test('with fenix', () async {
+      Get.put(DisposableController());
+      Get.lazyReplace<DisposableController>(() => Controller(), fenix: true);
+      expect(Get.find<DisposableController>(), isA<Controller>());
+      (Get.find<DisposableController>() as Controller).increment();
+
+      expect((Get.find<DisposableController>() as Controller).count, 1);
+      Get.delete<DisposableController>();
+      expect((Get.find<DisposableController>() as Controller).count, 0);
+    });
+
+    test('with fenix when parent is permanent', () async {
+      Get.put(DisposableController(), permanent: true);
+      Get.lazyReplace<DisposableController>(() => Controller());
+      final instance = Get.find<DisposableController>();
+      expect(instance, isA<Controller>());
+      (instance as Controller).increment();
+
+      expect((Get.find<DisposableController>() as Controller).count, 1);
+      Get.delete<DisposableController>();
+      expect((Get.find<DisposableController>() as Controller).count, 0);
     });
   });
 }

--- a/test/instance/get_instance_test.dart
+++ b/test/instance/get_instance_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
+
 import 'util/matcher.dart' as m;
 
 class Mock {
@@ -154,6 +155,13 @@ void main() {
       expect(instance, Get.find<DisposableController>());
       expect(instance.initialized, true);
     });
+  });
+
+  test('Get.replace test for replacing parent instance with child', () async {
+    Get.replace<DisposableController, Controller>(Controller());
+    final instance = Get.find<DisposableController>();
+    expect(instance is Controller, isTrue);
+    expect((instance as Controller).init, greaterThan(0));
   });
 }
 

--- a/test/instance/get_instance_test.dart
+++ b/test/instance/get_instance_test.dart
@@ -157,9 +157,40 @@ void main() {
     });
   });
 
-  test('Get.replace test for replacing parent instance with child', () async {
+  test('Get.replace test for replacing temporary parent instance with child',
+      () async {
+    Get.put(DisposableController());
     Get.replace<DisposableController, Controller>(Controller());
     final instance = Get.find<DisposableController>();
+    expect(instance is Controller, isTrue);
+    expect((instance as Controller).init, greaterThan(0));
+  });
+
+  test('Get.replace test for replacing permanent parent instance with child',
+      () async {
+    Get.put(DisposableController(), permanent: true);
+    Get.replace<DisposableController, Controller>(Controller());
+    final instance = Get.find<DisposableController>();
+    expect(instance is Controller, isTrue);
+    expect((instance as Controller).init, greaterThan(0));
+  });
+
+  test('Get.replace test for replacing tagged temporary instance with child',
+      () async {
+    final tag = 'tag';
+    Get.put(DisposableController(), tag: tag);
+    Get.replace<DisposableController, Controller>(Controller(), tag: tag);
+    final instance = Get.find<DisposableController>(tag: tag);
+    expect(instance is Controller, isTrue);
+    expect((instance as Controller).init, greaterThan(0));
+  });
+
+  test('Get.replace test for replacing tagged parent instance with child',
+      () async {
+    final tag = 'tag';
+    Get.put(DisposableController(), permanent: true, tag: tag);
+    Get.replace<DisposableController, Controller>(Controller(), tag: tag);
+    final instance = Get.find<DisposableController>(tag: tag);
     expect(instance is Controller, isTrue);
     expect((instance as Controller).init, greaterThan(0));
   });


### PR DESCRIPTION
This PR adds a `replace` method to allow specifying an alternate instance to be retrieved from the dependency injector. This replicates functionality present in other frameworks (eg. [Angular](https://angular.io/guide/dependency-injection-providers#specifying-an-alternative-class-provider))

```dart
class ParentClass {}

class ChildClass extends ParentClass {
  bool isChild = true;
}

Get.put(ParentClass());

Get.replace<ParentClass, ChildClass>(ChildClass());

final instance = Get.find<ParentClass>();
print(instance is ChildClass); //true
```

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
