### PR TITLE
Add scaffoldMessangerKey to GetMaterialApp class

### DIFF
--- a/example_nav2/windows/flutter/generated_plugin_registrant.cc
+++ b/example_nav2/windows/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
 

--- a/example_nav2/windows/flutter/generated_plugin_registrant.h
+++ b/example_nav2/windows/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/lib/get_navigation/src/root/get_material_app.dart
+++ b/lib/get_navigation/src/root/get_material_app.dart
@@ -292,6 +292,7 @@ class GetMaterialApp extends StatelessWidget {
               key: _.unikey,
               navigatorKey:
                   (navigatorKey == null ? Get.key : Get.addKey(navigatorKey!)),
+              scaffoldMessengerKey: scaffoldMessengerKey,
               home: home,
               routes: routes ?? const <String, WidgetBuilder>{},
               initialRoute: initialRoute,

--- a/lib/get_navigation/src/root/get_material_app.dart
+++ b/lib/get_navigation/src/root/get_material_app.dart
@@ -13,6 +13,7 @@ class GetMaterialApp extends StatelessWidget {
   const GetMaterialApp({
     Key? key,
     this.navigatorKey,
+    this.scaffoldMessengerKey,
     this.home,
     Map<String, Widget Function(BuildContext)> this.routes =
         const <String, WidgetBuilder>{},
@@ -71,6 +72,7 @@ class GetMaterialApp extends StatelessWidget {
         super(key: key);
 
   final GlobalKey<NavigatorState>? navigatorKey;
+  final GlobalKey<ScaffoldMessengerState>? scaffoldMessengerKey;
   final Widget? home;
   final Map<String, WidgetBuilder>? routes;
   final String? initialRoute;
@@ -128,6 +130,7 @@ class GetMaterialApp extends StatelessWidget {
   GetMaterialApp.router({
     Key? key,
     this.routeInformationProvider,
+    this.scaffoldMessengerKey,
     RouteInformationParser<Object>? routeInformationParser,
     RouterDelegate<Object>? routerDelegate,
     this.backButtonDispatcher,
@@ -252,6 +255,7 @@ class GetMaterialApp extends StatelessWidget {
           ? MaterialApp.router(
               routerDelegate: routerDelegate!,
               routeInformationParser: routeInformationParser!,
+              scaffoldMessengerKey: scaffoldMessengerKey,
               backButtonDispatcher: backButtonDispatcher,
               routeInformationProvider: routeInformationProvider,
               key: _.unikey,


### PR DESCRIPTION
Recently Flutter made changes about how snackbar should appear and made snackbars to show without depending on current context as if snackbar is shown and current route is removed snackbar will still appear so in this PR and i extended GetMaterialApp with scaffoldMessangerKey.
