### PR TITLE
feat: Ability to Add Scroll Behavior

### DIFF
--- a/lib/get_navigation/src/root/get_material_app.dart
+++ b/lib/get_navigation/src/root/get_material_app.dart
@@ -43,6 +43,7 @@ class GetMaterialApp extends StatelessWidget {
     this.showSemanticsDebugger = false,
     this.debugShowCheckedModeBanner = true,
     this.shortcuts,
+    this.scrollBehavior,
     this.customTransition,
     this.translationsKeys,
     this.translations,
@@ -101,6 +102,7 @@ class GetMaterialApp extends StatelessWidget {
   final bool showSemanticsDebugger;
   final bool debugShowCheckedModeBanner;
   final Map<LogicalKeySet, Intent>? shortcuts;
+  final ScrollBehavior? scrollBehavior;
   final ThemeData? highContrastTheme;
   final ThemeData? highContrastDarkTheme;
   final Map<Type, Action<Intent>>? actions;
@@ -152,6 +154,7 @@ class GetMaterialApp extends StatelessWidget {
     this.showSemanticsDebugger = false,
     this.debugShowCheckedModeBanner = true,
     this.shortcuts,
+    this.scrollBehavior,
     this.actions,
     this.customTransition,
     this.translationsKeys,
@@ -283,6 +286,7 @@ class GetMaterialApp extends StatelessWidget {
               showSemanticsDebugger: showSemanticsDebugger,
               debugShowCheckedModeBanner: debugShowCheckedModeBanner,
               shortcuts: shortcuts,
+              scrollBehavior: scrollBehavior,
             )
           : MaterialApp(
               key: _.unikey,
@@ -332,6 +336,7 @@ class GetMaterialApp extends StatelessWidget {
               showSemanticsDebugger: showSemanticsDebugger,
               debugShowCheckedModeBanner: debugShowCheckedModeBanner,
               shortcuts: shortcuts,
+              scrollBehavior: scrollBehavior,
               //   actions: actions,
             ));
 }


### PR DESCRIPTION
solve this issue https://github.com/jonataslaw/getx/issues/1557

There is a new way to remove Overscroll Glow,
as Flutter deprecates `buildViewportChrome`

For more info :
https://stackoverflow.com/a/68477729/2362966

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [ ] All existing and new tests are passing.
