### PR TITLE
Make `Rx<T>().stream` null-safe

### DIFF
--- a/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
+++ b/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
@@ -109,7 +109,7 @@ mixin RxObjectMixin<T> on NotifyManager<T> {
     return _value;
   }
 
-  Stream<T?> get stream => subject.stream;
+  Stream<T> get stream => subject.stream;
 
   /// Binds an existing `Stream<T>` to this Rx<T> to keep the values in sync.
   /// You can bind multiple sources to update the value.


### PR DESCRIPTION
RxImpl exposes the getter `stream`, which simply calls `subject.stream`, but transforms T to be optional, making these two statements incongruent:

```dart
true.obs.subject.stream.listen<bool>((bool val) => val);
true.obs.stream.listen<bool?>((bool? val) => val); // forced to be optional
```

Working on this checklist:

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [ ] All existing and new tests are passing.
