### PR TITLE
added PageBindings that references GetPageRoute in  [dependencies] method

### DIFF
--- a/lib/get_instance/src/bindings_interface.dart
+++ b/lib/get_instance/src/bindings_interface.dart
@@ -1,3 +1,5 @@
+import '../../get_navigation/src/routes/default_route.dart';
+
 import 'get_instance.dart';
 
 /// [Bindings] should be extended or implemented.
@@ -8,6 +10,11 @@ import 'get_instance.dart';
 // ignore: one_member_abstracts
 abstract class Bindings {
   void dependencies();
+}
+
+abstract class PageBindings extends Bindings {
+  @override
+  void dependencies([GetPageRoute? page]);
 }
 
 /// Simplifies Bindings generation from a single callback.

--- a/lib/get_navigation/src/nav2/get_router_delegate.dart
+++ b/lib/get_navigation/src/nav2/get_router_delegate.dart
@@ -299,14 +299,6 @@ class GetDelegate extends RouterDelegate<GetNavConfig>
     );
   }
 
-  // @override
-  // Future<void> setInitialRoutePath(GetNavConfig configuration) async {
-  //   //no need to clear history with Reorder route strategy
-  //   // _unsafeHistoryClear();
-  //   // _resultCompleter.clear();
-  //   await pushHistory(configuration);
-  // }
-
   @override
   Future<void> setNewRoutePath(GetNavConfig configuration) async {
     await pushHistory(configuration);

--- a/lib/get_navigation/src/routes/default_route.dart
+++ b/lib/get_navigation/src/routes/default_route.dart
@@ -89,11 +89,15 @@ class GetPageRoute<T> extends PageRoute<T> with GetPageRouteTransitionMixin<T> {
   Widget buildContent(BuildContext context) {
     final middlewareRunner = MiddlewareRunner(middlewares);
     final bindingsToBind = middlewareRunner.runOnBindingsStart(bindings);
-
-    binding?.dependencies();
-    if (bindingsToBind != null) {
-      for (final binding in bindingsToBind) {
-        binding.dependencies();
+    final _bindingList = [
+      if (binding != null) binding!,
+      ...?bindingsToBind,
+    ];
+    for (var _b in _bindingList) {
+      if (_b is PageBindings) {
+        _b.dependencies(this);
+      } else {
+        _b.dependencies();
       }
     }
 


### PR DESCRIPTION
this adds `abstract class PageBindings extends Bindings` that references the `GetPageRoute` object in its `void dependencies([GetPageRoute? page]);`

useful in navigation 2.0 when using `GetRouterOutlet` with `initialRoute` that requires parameters (Since the route isn't added to the history stack, we can't access its parameters from the router delegate).
