### PR TITLE
Fixed timeout issue

### DIFF
--- a/lib/get_connect/http/src/http.dart
+++ b/lib/get_connect/http/src/http.dart
@@ -205,6 +205,7 @@ class GetHttpClient {
       if (authenticate) await _modifier.authenticator!(request);
       final newRequest = await _modifier.modifyRequest<T>(request);
 
+      _httpClient.timeout = timeout;
       var response = await _httpClient.send<T>(newRequest);
 
       final newResponse =

--- a/lib/get_connect/http/src/http/html/http_request_html.dart
+++ b/lib/get_connect/http/src/http/html/http_request_html.dart
@@ -23,6 +23,9 @@ class HttpRequestImpl implements HttpRequestBase {
   ///on different sites. The default is false
   final bool withCredentials;
 
+  @override
+  Duration? timeout;
+
   /// Sends an HTTP request and asynchronously returns the response.
   @override
   Future<Response<T>> send<T>(Request<T> request) async {
@@ -30,6 +33,7 @@ class HttpRequestImpl implements HttpRequestBase {
     html.HttpRequest xhr;
 
     xhr = html.HttpRequest()
+      ..timeout = timeout?.inMilliseconds
       ..open(request.method, '${request.url}', async: true); // check this
 
     _xhrs.add(xhr);

--- a/lib/get_connect/http/src/http/interface/request_base.dart
+++ b/lib/get_connect/http/src/http/interface/request_base.dart
@@ -8,4 +8,12 @@ abstract class HttpRequestBase {
 
   /// Closes the [Request] and cleans up any resources associated with it.
   void close();
+
+  /// Gets and sets the timeout.
+  ///
+  /// For mobile, this value will be applied for both connection and request
+  /// timeout.
+  ///
+  /// For web, this value will be the request timeout.
+  Duration? timeout;
 }


### PR DESCRIPTION
The timeout property is not being used in GetConnect.
Fixed to utilize the timeout value:
- Mobile - The value is applied to both connection and request timeout.
- Web - The value is applied to request timeout.