### PR TITLE
Allow GetRouterOutlet to specify GetDelegate

### DIFF
--- a/lib/get_navigation/src/nav2/router_outlet.dart
+++ b/lib/get_navigation/src/nav2/router_outlet.dart
@@ -81,6 +81,7 @@ class GetRouterOutlet extends RouterOutlet<GetDelegate, GetNavConfig> {
     required String initialRoute,
     Iterable<GetPage> Function(Iterable<GetPage> afterAnchor)? filterPages,
     GlobalKey<NavigatorState>? key,
+    GetDelegate? delegate,
   }) : this.pickPages(
           pickPages: (config) {
             Iterable<GetPage<dynamic>> ret;
@@ -102,6 +103,7 @@ class GetRouterOutlet extends RouterOutlet<GetDelegate, GetNavConfig> {
               Get.routeTree.matchRoute(initialRoute).route ??
               delegate.notFoundRoute,
           key: key,
+          delegate: delegate,
         );
   GetRouterOutlet.pickPages({
     Widget Function(GetDelegate delegate)? emptyWidget,
@@ -109,6 +111,7 @@ class GetRouterOutlet extends RouterOutlet<GetDelegate, GetNavConfig> {
     required Iterable<GetPage> Function(GetNavConfig currentNavStack) pickPages,
     bool Function(Route<dynamic>, dynamic)? onPopPage,
     GlobalKey<NavigatorState>? key,
+    GetDelegate? delegate,
   }) : super(
           pageBuilder: (context, rDelegate, pages) {
             final pageRes = <GetPage?>[
@@ -134,7 +137,7 @@ class GetRouterOutlet extends RouterOutlet<GetDelegate, GetNavConfig> {
             return (emptyWidget?.call(rDelegate) ?? SizedBox.shrink());
           },
           pickPages: pickPages,
-          delegate: Get.rootDelegate,
+          delegate: delegate ?? Get.rootDelegate,
         );
 
   GetRouterOutlet.builder({


### PR DESCRIPTION
GetRouterOutlet is being forced to use the rootDelegate, but there are instances where we may need to specify the delegate, like when multiple delegates may be needed. This simple change provides that ability.

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [ ] All existing and new tests are passing.
