### PR TITLE
Allow listening to Rx with an initial value

### DIFF
--- a/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
+++ b/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
@@ -111,6 +111,24 @@ mixin RxObjectMixin<T> on NotifyManager<T> {
 
   Stream<T> get stream => subject.stream;
 
+  /// Returns a [StreamSubscription] similar to [listen], but with the
+  /// added benefit that it primes the stream with the current [value], rather
+  /// than waiting for the next [value]. This should not be called in [onInit]
+  /// or anywhere else during the build process.
+  StreamSubscription<T> listenAndPump(void Function(T event) onData,
+      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
+    final subscription = listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+
+    subject.add(value);
+
+    return subscription;
+  }
+
   /// Binds an existing `Stream<T>` to this Rx<T> to keep the values in sync.
   /// You can bind multiple sources to update the value.
   /// Closing the subscription will happen automatically when the observer


### PR DESCRIPTION
This addresses https://github.com/jonataslaw/getx/issues/1724 by providing a simple way to listen to an observable with the initial value included.

## Pre-launch Checklist

- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [X] All existing and new tests are passing.
