### PR TITLE
Remove take that limits the router outlet depth

### DIFF
--- a/lib/get_navigation/src/nav2/router_outlet.dart
+++ b/lib/get_navigation/src/nav2/router_outlet.dart
@@ -90,7 +90,6 @@ class GetRouterOutlet extends RouterOutlet<GetDelegate, GetNavConfig> {
               final length = Uri.parse(initialRoute).pathSegments.length;
               return config.currentTreeBranch
                   .skip(length)
-                  .take(length)
                   .toList();
             }
             ret = config.currentTreeBranch.pickAfterRoute(anchorRoute);


### PR DESCRIPTION
If there is not anchor route present in a `RouterOutlet`, then the nesting level depth is limited to the number of path segments in the initial route. So if the initial route is `/a/b`, there are only 2 path segments (`a` and `b`), so the maximum depth for any route to displayed inside the `RouterOutlet` is 4 (`/a/b/c/d/e` is not accessible).

For example, take this app:

```dart
import 'package:flutter/material.dart';
import 'package:get/get.dart';

void main() {
  runApp(
    GetMaterialApp.router(
      title: "Application",
      getPages: [
        GetPage(
          name: '/',
          page: () => RootView(),
          participatesInRootNavigator: true,
          children: [
            GetPage(
              name: '/nested1',
              page: () => NestedView(depth: 1),
              children: [
                GetPage(
                  name: '/nested2',
                  page: () => NestedView(depth: 2),
                  children: [
                    GetPage(
                      name: '/nested3',
                      page: () => NestedView(depth: 3),
                      children: [
                        GetPage(
                          name: '/final',
                          page: () => FinalLevel(),
                        ),
                      ],
                    ),
                  ],
                ),
              ],
            ),
          ],
        ),
      ],
    ),
  );
}

class RootView extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return GetRouterOutlet.builder(
      builder: (context, delegate, currentRoute) {
        return GetRouterOutlet(
          key: Get.nestedKey(1),
          initialRoute: '/nested1',
        );
      },
    );
  }
}

class NestedView extends StatelessWidget {
  NestedView({
    Key? key,
    required this.depth,
  }) : super(key: Key('nested $depth'));

  final int depth;

  int get _nextLevel => depth + 1;

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: Text('Nested View $depth')),
      body: Center(
        child: ElevatedButton(
          child: Text('Go to nested view $_nextLevel'),
          onPressed: () {
            if (depth == 1) {
              Get.rootDelegate.toNamed('/nested1/nested2');
            } else if (depth == 2) {
              Get.rootDelegate.toNamed('/nested1/nested2/nested3');
            } else if (depth == 3) {
              Get.rootDelegate.toNamed('/nested1/nested2/nested3/final');
            }
          },
        ),
      ),
    );
  }
}

class FinalLevel extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: Text('Final Level')),
      body: Center(child: Text('You made it')),
    );
  }
}
```

Before this patch, the behavior looks like this:


https://user-images.githubusercontent.com/77690617/128922621-e4788512-8a56-4188-b1c5-09e79abfec3f.mov



After the patch, this is the behavior:


https://user-images.githubusercontent.com/77690617/128923061-e09d7a03-a0fa-43c1-9a9e-fa03119dd7ae.mov


I'm not 100% the purpose of the `take`. This is the change where it was introduced:

![Screen Shot 2021-08-10 at 3 31 35 PM](https://user-images.githubusercontent.com/77690617/128923334-27cec36f-968a-43ad-9161-31adf3da8a59.png)


## Pre-launch Checklist

- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [X] All existing and new tests are passing.
