### PR TITLE
fix try/catch case missed in socket_notifier

### DIFF
--- a/lib/get_connect/sockets/src/socket_notifier.dart
+++ b/lib/get_connect/sockets/src/socket_notifier.dart
@@ -72,7 +72,7 @@ class SocketNotifier {
       if (_onEvents!.containsKey(event)) {
         _onEvents![event]!(data);
       }
-    } on Exception catch (_) {
+    } catch (_) {
       return;
     }
   }


### PR DESCRIPTION
When JSON content is a List type, the catch syntax with `on Exception` in `_tryOn()` won't catch the error.
Deleting `on Exception` will the bug.

Every PR must update the corresponding documentation in the `code`, and also the readme in english with the following changes.

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
