### PR TITLE
Missing arguments of copyWith

### DIFF
--- a/lib/get_connect/http/src/request/request.dart
+++ b/lib/get_connect/http/src/request/request.dart
@@ -80,18 +80,14 @@ class Request<T> {
     String? method,
     Map<String, String>? headers,
     Stream<List<int>>? bodyBytes,
-    bool followRedirects = true,
-    int maxRedirects = 4,
+    bool? followRedirects,
+    int? maxRedirects,
     int? contentLength,
     FormData? files,
-    bool persistentConnection = true,
+    bool? persistentConnection,
     Decoder<T>? decoder,
     bool appendHeader = true,
   }) {
-    if (followRedirects) {
-      assert(maxRedirects > 0);
-    }
-
     // If appendHeader is set to true, we will merge origin headers with that
     if (appendHeader && headers != null) {
       headers.addAll(this.headers);
@@ -100,13 +96,13 @@ class Request<T> {
     return Request<T>._(
       url: url ?? this.url,
       method: method ?? this.method,
-      bodyBytes: bodyBytes ??= BodyBytesStream.fromBytes(const []),
+      bodyBytes: bodyBytes ?? this.bodyBytes,
       headers: headers == null ? this.headers : Map.from(headers),
-      followRedirects: followRedirects,
-      maxRedirects: maxRedirects,
+      followRedirects: followRedirects ?? this.followRedirects,
+      maxRedirects: maxRedirects ?? this.maxRedirects,
       contentLength: contentLength ?? this.contentLength,
       files: files ?? this.files,
-      persistentConnection: persistentConnection,
+      persistentConnection: persistentConnection ?? this.persistentConnection,
       decoder: decoder ?? this.decoder,
     );
   }


### PR DESCRIPTION
Some attributes were being overwritten, such as bodyBytes, causing a problem in their copy inside the addRequestModifier method.