### PR TITLE
Fix RxList.removeWhere calls 'ever' multiple times

### DIFF
--- a/lib/get_rx/src/rx_types/rx_iterables/rx_list.dart
+++ b/lib/get_rx/src/rx_types/rx_iterables/rx_list.dart
@@ -73,6 +73,18 @@ class RxList<E> extends ListMixin<E>
   }
 
   @override
+  void removeWhere(bool test(E element)) {
+    _value.removeWhere(test);
+    refresh();
+  }
+
+  @override
+  void retainWhere(bool test(E element)) {
+    _value.retainWhere(test);
+    refresh();
+  }
+
+  @override
   int get length => value.length;
 
   @override

--- a/test/rx/rx_workers_test.dart
+++ b/test/rx/rx_workers_test.dart
@@ -162,4 +162,31 @@ void main() {
     expect(reactiveString.endsWith("c"), true);
     expect(currentString, "abc");
   });
+
+  test('Number of times "ever" is called in RxList', () async {
+    final list = [1, 2, 3].obs;
+    var count = 0;
+    ever<List<int>>(list, (value) {
+      count++;
+    });
+
+    list.add(4);
+    await Future.delayed(Duration.zero);
+    expect(count, 1);
+
+    count = 0;
+    list.addAll([4, 5]);
+    await Future.delayed(Duration.zero);
+    expect(count, 1);
+
+    count = 0;
+    list.removeWhere((element) => element == 2);
+    await Future.delayed(Duration.zero);
+    expect(count, 1);
+
+    count = 0;
+    list.retainWhere((element) => element == 1);
+    await Future.delayed(Duration.zero);
+    expect(count, 1);
+  });
 }


### PR DESCRIPTION
A single call to RxList.removeWhere will call "ever" multiple times.
The same goes for retainWhere.

It should pass the following test, but in fact it does not.

```dart
    final list = [1, 2, 3].obs;
    var count = 0;
    ever<List<int>>(list, (value) {
      count++;
    });
    list.removeWhere((element) => element == 2);
    await Future.delayed(Duration.zero);
    expect(count, 1);
```

So I fixed it.

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
