### PR TITLE
Pump the listener, don't notify all listeners

### DIFF
--- a/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
+++ b/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
@@ -117,16 +117,14 @@ mixin RxObjectMixin<T> on NotifyManager<T> {
   /// or anywhere else during the build process.
   StreamSubscription<T> listenAndPump(void Function(T event) onData,
       {Function? onError, void Function()? onDone, bool? cancelOnError}) {
-    final subscription = listen(
+    onData(value);
+
+    return listen(
       onData,
       onError: onError,
       onDone: onDone,
       cancelOnError: cancelOnError,
     );
-
-    subject.add(value);
-
-    return subscription;
   }
 
   /// Binds an existing `Stream<T>` to this Rx<T> to keep the values in sync.


### PR DESCRIPTION
This makes a minor tweak to `listenAndPump` so that it no longer notifies all listeners.

## Pre-launch Checklist

- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [X] All existing and new tests are passing.
