### PR TITLE
Printing GetInformationParser as GetLog

### DIFF
--- a/lib/get_navigation/src/nav2/get_information_parser.dart
+++ b/lib/get_navigation/src/nav2/get_information_parser.dart
@@ -14,7 +14,7 @@ class GetInformationParser extends RouteInformationParser<GetNavConfig> {
   SynchronousFuture<GetNavConfig> parseRouteInformation(
     RouteInformation routeInformation,
   ) {
-    print('GetInformationParser: route location: ${routeInformation.location}');
+    Get.log('GetInformationParser: route location: ${routeInformation.location}');
     var location = routeInformation.location;
     if (location == '/') {
       //check if there is a corresponding page


### PR DESCRIPTION
Replace print() method with Get.log()

