### PR TITLE
markAsDirty must use permenent property

### DIFF
--- a/lib/get_instance/src/get_instance.dart
+++ b/lib/get_instance/src/get_instance.dart
@@ -239,7 +239,7 @@ class GetInstance {
     final newKey = key ?? _getKey(S, tag);
     if (_singl.containsKey(newKey)) {
       final dep = _singl[newKey];
-      if (dep != null) {
+      if (dep != null && !dep.permanent) {
         dep.isDirty = true;
       }
     }


### PR DESCRIPTION
markAsDirty method doesn't take into account permanent property of controller. So, permanent controllers are re-creating every Get.find call.

In previous versions all worked fine. I added this check
 if (dep != null && !dep.permanent) {

