### PR TITLE
Add a errorLoadingMore constructor in RxStatus class

### DIFF
--- a/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
+++ b/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
@@ -161,6 +161,7 @@ class RxStatus {
   final bool isSuccess;
   final bool isEmpty;
   final bool isLoadingMore;
+  final bool isErrorLoadingMore;
   final String? errorMessage;
 
   RxStatus._({
@@ -170,6 +171,7 @@ class RxStatus {
     this.isSuccess = false,
     this.errorMessage,
     this.isLoadingMore = false,
+    this.isErrorLoadingMore = false,
   });
 
   factory RxStatus.loading() {
@@ -186,6 +188,10 @@ class RxStatus {
 
   factory RxStatus.error([String? message]) {
     return RxStatus._(isError: true, errorMessage: message);
+  }
+
+  factory RxStatus.errorLoadingMore([String? message]) {
+    return RxStatus._(isErrorLoadingMore: true, errorMessage: message);
   }
 
   factory RxStatus.empty() {


### PR DESCRIPTION
when there is error on loading more data it is not necessary to show the errorScreen, same as when status is changed from success to loading more, the "onsuccess" screen remains. Let me know if this pr will be accepted then I add it in the documentation.