### PR TITLE
rename HttpStatus class to HttpStatusHelper and remove unnecessary status codes

### DIFF
--- a/lib/get_connect/http/src/http.dart
+++ b/lib/get_connect/http/src/http.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import '../src/certificates/certificates.dart';
 import '../src/exceptions/exceptions.dart';
 import '../src/multipart/form_data.dart';
 import '../src/request/request.dart';
 import '../src/response/response.dart';
-import '../src/status/http_status.dart';
 import 'http/interface/request_base.dart';
 import 'http/stub/http_request_stub.dart'
     if (dart.library.html) 'http/html/http_request_html.dart'

--- a/lib/get_connect/http/src/response/response.dart
+++ b/lib/get_connect/http/src/response/response.dart
@@ -42,12 +42,12 @@ class Response<T> {
   /// Human-readable context for [statusCode].
   final String? statusText;
 
-  /// [HttpStatus] from [Response]. `status.connectionError` is true
+  /// [HttpStatusHelper] from [Response]. `status.connectionError` is true
   /// when statusCode is null. `status.isUnauthorized` is true when
   /// statusCode is equal `401`. `status.isNotFound` is true when
   /// statusCode is equal `404`. `status.isServerError` is true when
   /// statusCode is between `500` and `599`.
-  HttpStatus get status => HttpStatus(statusCode);
+  HttpStatusHelper get status => HttpStatusHelper(statusCode);
 
   /// `hasError` is true when statusCode is not between 200 and 299.
   bool get hasError => status.hasError;

--- a/lib/get_connect/http/src/status/http_status.dart
+++ b/lib/get_connect/http/src/status/http_status.dart
@@ -1,86 +1,22 @@
-class HttpStatus {
-  HttpStatus(this.code);
+import 'dart:io';
+
+class HttpStatusHelper {
+  HttpStatusHelper(this.code);
 
   final int? code;
 
-  static const int continue_ = 100;
-  static const int switchingProtocols = 101;
-  static const int processing = 102;
-  static const int earlyHints = 103;
-  static const int ok = 200;
-  static const int created = 201;
-  static const int accepted = 202;
-  static const int nonAuthoritativeInformation = 203;
-  static const int noContent = 204;
-  static const int resetContent = 205;
-  static const int partialContent = 206;
-  static const int multiStatus = 207;
-  static const int alreadyReported = 208;
-  static const int imUsed = 226;
-  static const int multipleChoices = 300;
-  static const int movedPermanently = 301;
-  static const int found = 302;
-  static const int movedTemporarily = 302; // Common alias for found.
-  static const int seeOther = 303;
-  static const int notModified = 304;
-  static const int useProxy = 305;
-  static const int switchProxy = 306;
-  static const int temporaryRedirect = 307;
-  static const int permanentRedirect = 308;
-  static const int badRequest = 400;
-  static const int unauthorized = 401;
-  static const int paymentRequired = 402;
-  static const int forbidden = 403;
-  static const int notFound = 404;
-  static const int methodNotAllowed = 405;
-  static const int notAcceptable = 406;
-  static const int proxyAuthenticationRequired = 407;
-  static const int requestTimeout = 408;
-  static const int conflict = 409;
-  static const int gone = 410;
-  static const int lengthRequired = 411;
-  static const int preconditionFailed = 412;
-  static const int requestEntityTooLarge = 413;
-  static const int requestUriTooLong = 414;
-  static const int unsupportedMediaType = 415;
-  static const int requestedRangeNotSatisfiable = 416;
-  static const int expectationFailed = 417;
-  static const int imATeapot = 418;
-  static const int misdirectedRequest = 421;
-  static const int unprocessableEntity = 422;
-  static const int locked = 423;
-  static const int failedDependency = 424;
-  static const int tooEarly = 425;
-  static const int upgradeRequired = 426;
-  static const int preconditionRequired = 428;
-  static const int tooManyRequests = 429;
-  static const int requestHeaderFieldsTooLarge = 431;
-  static const int connectionClosedWithoutResponse = 444;
-  static const int unavailableForLegalReasons = 451;
-  static const int clientClosedRequest = 499;
-  static const int internalServerError = 500;
-  static const int notImplemented = 501;
-  static const int badGateway = 502;
-  static const int serviceUnavailable = 503;
-  static const int gatewayTimeout = 504;
-  static const int httpVersionNotSupported = 505;
-  static const int variantAlsoNegotiates = 506;
-  static const int insufficientStorage = 507;
-  static const int loopDetected = 508;
-  static const int notExtended = 510;
-  static const int networkAuthenticationRequired = 511;
-  static const int networkConnectTimeoutError = 599;
-
   bool get connectionError => code == null;
 
-  bool get isUnauthorized => code == unauthorized;
+  bool get isUnauthorized => code == HttpStatus.unauthorized;
 
-  bool get isForbidden => code == forbidden;
+  bool get isForbidden => code == HttpStatus.forbidden;
 
-  bool get isNotFound => code == notFound;
+  bool get isNotFound => code == HttpStatus.notFound;
 
-  bool get isServerError =>
-      between(internalServerError, networkConnectTimeoutError);
+  bool get isServerError => between(
+        HttpStatus.internalServerError,
+        HttpStatus.networkConnectTimeoutError,
+      );
 
   bool between(int begin, int end) {
     return !connectionError && code! >= begin && code! <= end;


### PR DESCRIPTION
# Why ? 
- to avoid conflict with `dart:io`  `HttpStatus`
- codes already  out there in the dart SDK why write them again ! 

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
