### PR TITLE
add / pass-through useInheritedMediaQuery

### DIFF
--- a/lib/get_navigation/src/root/get_cupertino_app.dart
+++ b/lib/get_navigation/src/root/get_cupertino_app.dart
@@ -43,6 +43,7 @@ class GetCupertinoApp extends StatelessWidget {
     this.checkerboardOffscreenLayers = false,
     this.showSemanticsDebugger = false,
     this.debugShowCheckedModeBanner = true,
+    this.useInheritedMediaQuery = false,
     this.shortcuts,
     this.smartManagement = SmartManagement.full,
     this.initialBinding,
@@ -93,6 +94,7 @@ class GetCupertinoApp extends StatelessWidget {
   final bool checkerboardOffscreenLayers;
   final bool showSemanticsDebugger;
   final bool debugShowCheckedModeBanner;
+  final bool useInheritedMediaQuery;
   final Map<LogicalKeySet, Intent>? shortcuts;
   final ThemeData? highContrastTheme;
   final ThemeData? highContrastDarkTheme;
@@ -141,6 +143,7 @@ class GetCupertinoApp extends StatelessWidget {
     this.checkerboardOffscreenLayers = false,
     this.showSemanticsDebugger = false,
     this.debugShowCheckedModeBanner = true,
+    this.useInheritedMediaQuery = false,
     this.shortcuts,
     this.actions,
     this.customTransition,
@@ -270,6 +273,7 @@ class GetCupertinoApp extends StatelessWidget {
                 checkerboardOffscreenLayers: checkerboardOffscreenLayers,
                 showSemanticsDebugger: showSemanticsDebugger,
                 debugShowCheckedModeBanner: debugShowCheckedModeBanner,
+                useInheritedMediaQuery: useInheritedMediaQuery,
                 shortcuts: shortcuts,
               )
             : CupertinoApp(
@@ -309,6 +313,7 @@ class GetCupertinoApp extends StatelessWidget {
                 checkerboardOffscreenLayers: checkerboardOffscreenLayers,
                 showSemanticsDebugger: showSemanticsDebugger,
                 debugShowCheckedModeBanner: debugShowCheckedModeBanner,
+                useInheritedMediaQuery: useInheritedMediaQuery,
                 shortcuts: shortcuts,
                 //   actions: actions,
               ),

--- a/lib/get_navigation/src/root/get_material_app.dart
+++ b/lib/get_navigation/src/root/get_material_app.dart
@@ -43,6 +43,7 @@ class GetMaterialApp extends StatelessWidget {
     this.checkerboardOffscreenLayers = false,
     this.showSemanticsDebugger = false,
     this.debugShowCheckedModeBanner = true,
+    this.useInheritedMediaQuery = false,
     this.shortcuts,
     this.scrollBehavior,
     this.customTransition,
@@ -103,6 +104,7 @@ class GetMaterialApp extends StatelessWidget {
   final bool checkerboardOffscreenLayers;
   final bool showSemanticsDebugger;
   final bool debugShowCheckedModeBanner;
+  final bool useInheritedMediaQuery;
   final Map<LogicalKeySet, Intent>? shortcuts;
   final ScrollBehavior? scrollBehavior;
   final ThemeData? highContrastTheme;
@@ -156,6 +158,7 @@ class GetMaterialApp extends StatelessWidget {
     this.checkerboardOffscreenLayers = false,
     this.showSemanticsDebugger = false,
     this.debugShowCheckedModeBanner = true,
+    this.useInheritedMediaQuery = false,
     this.shortcuts,
     this.scrollBehavior,
     this.actions,
@@ -293,6 +296,7 @@ class GetMaterialApp extends StatelessWidget {
                 checkerboardOffscreenLayers: checkerboardOffscreenLayers,
                 showSemanticsDebugger: showSemanticsDebugger,
                 debugShowCheckedModeBanner: debugShowCheckedModeBanner,
+                useInheritedMediaQuery: useInheritedMediaQuery,
                 shortcuts: shortcuts,
                 scrollBehavior: scrollBehavior,
               )
@@ -338,6 +342,7 @@ class GetMaterialApp extends StatelessWidget {
                 checkerboardOffscreenLayers: checkerboardOffscreenLayers,
                 showSemanticsDebugger: showSemanticsDebugger,
                 debugShowCheckedModeBanner: debugShowCheckedModeBanner,
+                useInheritedMediaQuery: useInheritedMediaQuery,
                 shortcuts: shortcuts,
                 scrollBehavior: scrollBehavior,
                 //   actions: actions,


### PR DESCRIPTION
Allow passing through useInheritedMediaQuery to MaterialApp / MaterialApp.router and CupertinoApp / CupertinoApp.router allowing custom root MediaQuery widgets that are inherited through the app.