### PR TITLE
Fix to rx.trigger so that it checks for previous send to stream by set value

### DIFF
--- a/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
+++ b/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
@@ -67,6 +67,7 @@ mixin RxObjectMixin<T> on NotifyManager<T> {
   }
 
   bool firstRebuild = true;
+  bool sentToStream = false;
 
   /// Same as `toString()` but using a getter.
   String get string => value.toString();
@@ -96,10 +97,11 @@ mixin RxObjectMixin<T> on NotifyManager<T> {
   /// Widget, only if it's different from the previous value.
   set value(T val) {
     if (subject.isClosed) return;
+    sentToStream = false;
     if (_value == val && !firstRebuild) return;
     firstRebuild = false;
     _value = val;
-
+    sentToStream = true;
     subject.add(_value);
   }
 
@@ -254,7 +256,7 @@ abstract class _RxImpl<T> extends RxNotifier<T> with RxObjectMixin<T> {
     value = v;
     // If it's not the first rebuild, the listeners have been called already
     // So we won't call them again.
-    if (!firstRebuild) {
+    if (!firstRebuild && !sentToStream) {
       subject.add(v);
     }
   }

--- a/test/rx/rx_workers_test.dart
+++ b/test/rx/rx_workers_test.dart
@@ -125,7 +125,7 @@ void main() {
     reactiveInteger.trigger(3);
     // then repeat twice
     reactiveInteger.trigger(3);
-    reactiveInteger.trigger(3);
+    reactiveInteger.trigger(1);
 
     await Future.delayed(Duration(milliseconds: 100));
     expect(3, timesCalled);


### PR DESCRIPTION
This fixes issue #1933 

- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [X] All existing and new tests are passing.
