### PR TITLE
Fix GetXController to GetxController

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -473,7 +473,7 @@ Amateur Coder hizo un video asombroso sobre utilidades, almacenamiento, enlaces 
 | NumX    | `RxNum`    |
 | DoubleX | `RxDouble` |
 
-RxController y GetBuilder ahora se han fusionado, ya no necesita memorizar qué controlador desea usar, solo use GetXController, funcionará para gestión de estádo simple y también para reactivo.
+RxController y GetBuilder ahora se han fusionado, ya no necesita memorizar qué controlador desea usar, solo use GetxController, funcionará para gestión de estádo simple y también para reactivo.
 
 2- Rutas Nombradas
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1019,7 +1019,7 @@ RxController e GetBuilder agora viraram um só, você não precisa mais memoriza
 
 ```dart
 //Gerenciador de estado simples
-class Controller extends GetXController {
+class Controller extends GetxController {
   String nome = '';
 
   void atualizarNome(String novoNome) {
@@ -1030,7 +1030,7 @@ class Controller extends GetXController {
 ```
 
 ```dart
-class Controller extends GetXController {
+class Controller extends GetxController {
   final nome = ''.obs;
 
   // não precisa de um método direto pra atualizar o nome

--- a/documentation/es_ES/state_management.md
+++ b/documentation/es_ES/state_management.md
@@ -61,8 +61,8 @@ GetX tiene un gestor de estado que es extremadamente ligero y fácil de implemen
 ### Uso
 
 ```dart
-// Create controller class and extends GetXController
-class Controller extends GetXController {
+// Create controller class and extends GetxController
+class Controller extends GetxController {
   int counter = 0;
   void increment() {
     counter++;
@@ -104,7 +104,7 @@ class OtherClass extends StatelessWidget {
 Si necesita usar su Controller en muchos otros lugares y fuera de GetBuilder, simplemente cree un get en su Controller y obténgalo fácilmente. (o use `Get.find <Controller>()`)
 
 ```dart
-class Controller extends GetXController {
+class Controller extends GetxController {
 
   /// You do not need that. I recommend using it just for ease of syntax.
   /// with static method: Controller.to.increment();
@@ -178,12 +178,12 @@ Entonces, para simplificar esto:
 
 No necesita llamar a métodos en initState y enviarlos por parámetro a su Controller, ni usar un constructor Controller. Para eso tiene el método onInit() que se llamará en el momento adecuado para que sus servicios sean iniciados. No necesita llamar a dispose(), dado que dispone del método onClose() que se llamará en el momento exacto en que su Controller ya no se necesita, y se eliminará de la memoria. De esa manera, deje las vistas solo para widgets, y abstenerse de incluír cualquier tipo de lógica de negocios.
 
-No llame a un método dispose() dentro de GetXController, no hará nada, recuerde que Controller no es un widget, no debe "eliminarlo" y GetX lo eliminará de forma automática e inteligente de la memoria. Si utilizó algún stream en él y desea cerrarlo, simplemente insértelo en el método de cierre.
+No llame a un método dispose() dentro de GetxController, no hará nada, recuerde que Controller no es un widget, no debe "eliminarlo" y GetX lo eliminará de forma automática e inteligente de la memoria. Si utilizó algún stream en él y desea cerrarlo, simplemente insértelo en el método de cierre.
 
 Ejemplo:
 
 ```dart
-class Controller extends GetXController {
+class Controller extends GetxController {
   StreamController<User> user = StreamController<User>();
   StreamController<String> name = StreamController<String>();
 
@@ -219,7 +219,7 @@ GetBuilder<Controller>(
 También puede necesitar una instancia de su Controller fuera de su GetBuilder, y puede usar estos enfoques para lograr esto:
 
 ```dart
-class Controller extends GetXController {
+class Controller extends GetxController {
   static Controller get to => Get.find();
 [...]
 }
@@ -235,7 +235,7 @@ GetBuilder<Controller>(
 o
 
 ```dart
-class Controller extends GetXController {
+class Controller extends GetxController {
  // static Controller get to => Get.find(); // with no static get
 [...]
 }

--- a/documentation/kr_KO/state_management.md
+++ b/documentation/kr_KO/state_management.md
@@ -695,7 +695,7 @@ GetX는 위젯이 정말 값이 변경되었을 때에만 재빌드합니다. �
 
 단 하나의 반응변수(.obs)와 다른 메커니즘(update())가 모두 필요해서 Getbuilder 안에 Obx를 넣어야 하는 경우가 필요했습니다. 이 경우를 위해 MixinBuilder가 만들어졌습니다. ".obs"변수의 값이 바뀔 때 즉각적으로 바뀌는 것과 update()를 통해 바뀌는 것 모두를 지원합니다. 하지만, 이 위젯이 GetBuilder, GetX, Obx 보다 더 많은 리소스를 필요로합니다. 왜냐하면 controller의 update() 메소드와 자식으로부터의 .obs 변수의 변화를 주시하고 있어야 하기 때문입니다.
 
-GetxController를 상속(extends)하는 것은 중요합니다. onInit()과 onClose()에서 "시작"과 "종료" 이벤트를 수행할 수 있는 생명 주기를 갖고 있기 때문입니다. 이를 위해서 어떤 클래스를 사용해도 괜찮지만, obervable한 변수든 아니든 간에 GetXController를 사용해 변수를 다루길 적극 권장합니다.
+GetxController를 상속(extends)하는 것은 중요합니다. onInit()과 onClose()에서 "시작"과 "종료" 이벤트를 수행할 수 있는 생명 주기를 갖고 있기 때문입니다. 이를 위해서 어떤 클래스를 사용해도 괜찮지만, obervable한 변수든 아니든 간에 GetxController를 사용해 변수를 다루길 적극 권장합니다.
 
 
 ## GetBuilder vs GetX vs Obx vs MixinBuilder


### PR DESCRIPTION
Fix the wrong `GetxController` class name in some examples

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [ ] All existing and new tests are passing.
