### PR TITLE
[edited] We added PageRoute argument into CustomTransition.buildTransition

### DIFF
--- a/lib/get_navigation/src/routes/custom_transition.dart
+++ b/lib/get_navigation/src/routes/custom_transition.dart
@@ -2,7 +2,8 @@ import 'package:flutter/widgets.dart';
 
 // ignore: one_member_abstracts
 abstract class CustomTransition {
-  Widget buildTransition(
+  Widget buildTransition<T>(
+    PageRoute<T> route,
     BuildContext context,
     Curve? curve,
     Alignment? alignment,

--- a/lib/get_navigation/src/routes/get_transition_mixin.dart
+++ b/lib/get_navigation/src/routes/get_transition_mixin.dart
@@ -222,12 +222,13 @@ Cannot read the previousTitle for a route that has not yet been installed''',
             ? CurvedAnimation(parent: animation, curve: finalCurve)
             : animation,
         secondaryRouteAnimation: secondaryAnimation,
-        child: child,
         linearTransition: linearTransition,
+        child: child,
       );
     } else {
       if (route.customTransition != null) {
         return route.customTransition!.buildTransition(
+          route,
           context,
           finalCurve,
           route.alignment,
@@ -464,8 +465,14 @@ Cannot read the previousTitle for a route that has not yet been installed''',
 
         default:
           if (Get.customTransition != null) {
-            return Get.customTransition!.buildTransition(context, route.curve,
-                route.alignment, animation, secondaryAnimation, child);
+            return Get.customTransition!.buildTransition(
+                route,
+                context,
+                route.curve,
+                route.alignment,
+                animation,
+                secondaryAnimation,
+                child);
           }
 
           return PageTransitionsTheme().buildTransitions(


### PR DESCRIPTION
We added PageRoute argument into CustomTransition.buildTransition. This provides a complex way to create custom transitions

There is no elements to change at README.md

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
