### PR TITLE
Implements a get to make _singl available globally

### DIFF
--- a/lib/get_instance/src/get_instance.dart
+++ b/lib/get_instance/src/get_instance.dart
@@ -33,6 +33,8 @@ class GetInstance {
   /// `Get.put()`
   static final Map<String, _InstanceBuilderFactory> _singl = {};
 
+  static Map<String, _InstanceBuilderFactory> get registeredInstances => _singl;
+
   /// Holds a reference to every registered callback when using
   /// `Get.lazyPut()`
   // static final Map<String, _Lazy> _factory = {};


### PR DESCRIPTION
Utility example, when I change one controller data I want all controllers that EXTENDS an X class to call the "X.UPDATE()" method, so it would loop through all registered controllers checking if extends class X then call this "update" function.

## Pre-launch Checklist
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [X] All existing and new tests are passing.