### PR TITLE
Update internacionalization.dart Fixes #2039

### DIFF
--- a/lib/get_utils/src/extensions/internacionalization.dart
+++ b/lib/get_utils/src/extensions/internacionalization.dart
@@ -69,13 +69,13 @@ extension Trans on String {
     final translationsWithNoCountry = Get.translations
         .map((key, value) => MapEntry(key.split("_").first, value));
     final containsKey =
-        translationsWithNoCountry.containsKey(Get.locale!.languageCode);
+        translationsWithNoCountry.containsKey(Get.locale!.languageCode.split("_").first);
 
     if (!containsKey) {
       return null;
     }
 
-    return translationsWithNoCountry[Get.locale!.languageCode];
+    return translationsWithNoCountry[Get.locale!.languageCode.split("_").first];
   }
 
   String get tr {


### PR DESCRIPTION
Fixes #2039 
Localization don't work for Locale('en_US') or Locale('de_DE')

With this change, it supports both situations:
When locale has only language code like Locale('en') or Locale('en_US')


## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [ ] All existing and new tests are passing.
