### PR TITLE
fix: middleware can not get route arguments

### DIFF
--- a/lib/get_navigation/src/routes/route_middleware.dart
+++ b/lib/get_navigation/src/routes/route_middleware.dart
@@ -31,7 +31,7 @@ abstract class _RouteMiddleware {
   /// }
   /// ```
   /// {@end-tool}
-  RouteSettings? redirect(String route);
+  RouteSettings? redirect(String route, RouteSettings routeSettings);
 
   /// Similar to [redirect],
   /// This function will be called when the router delegate changes the
@@ -101,7 +101,7 @@ class GetMiddleware implements _RouteMiddleware {
   GetMiddleware({this.priority});
 
   @override
-  RouteSettings? redirect(String? route) => null;
+  RouteSettings? redirect(String? route, RouteSettings? routeSettings) => null;
 
   @override
   GetPage? onPageCalled(GetPage? page) => page;
@@ -143,10 +143,10 @@ class MiddlewareRunner {
     return page;
   }
 
-  RouteSettings? runRedirect(String? route) {
+  RouteSettings? runRedirect(String? route, RouteSettings? routeSettings) {
     RouteSettings? to;
     for (final element in _getMiddlewares()) {
-      to = element.redirect(route);
+      to = element.redirect(route, routeSettings);
       if (to != null) {
         break;
       }
@@ -273,7 +273,7 @@ class PageRedirect {
     if (match.route!.middlewares == null || match.route!.middlewares!.isEmpty) {
       return false;
     }
-    final newSettings = runner.runRedirect(settings!.name);
+    final newSettings = runner.runRedirect(settings!.name, settings);
     if (newSettings == null) {
       return false;
     }


### PR DESCRIPTION
Fix #1331 

Hi, I'm new to dart, I try to obtain arguments when redirecting, but I can't, so I just add a param to redirect middleware, I don't know if it's suitable, if it's suitable, I'll update the relevant documentation.

or, any other methods that can let me get the arguments at redirect middleware?

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [ ] All existing and new tests are passing.
