### PR TITLE
Personalizable Border Radius in Default Dialog

### DIFF
--- a/lib/get_navigation/src/extension_navigation.dart
+++ b/lib/get_navigation/src/extension_navigation.dart
@@ -192,7 +192,7 @@ extension ExtensionDialog on GetInterface {
                     color: buttonColor ?? theme.colorScheme.secondary,
                     width: 2,
                     style: BorderStyle.solid),
-                borderRadius: BorderRadius.circular(100)),
+                borderRadius: BorderRadius.circular(radius)),
           ),
           onPressed: () {
             onCancel?.call();
@@ -215,7 +215,7 @@ extension ExtensionDialog on GetInterface {
               tapTargetSize: MaterialTapTargetSize.shrinkWrap,
               backgroundColor: buttonColor ?? theme.colorScheme.secondary,
               shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(100)),
+                  borderRadius: BorderRadius.circular(radius)),
             ),
             child: Text(
               textConfirm ?? "Ok",


### PR DESCRIPTION
Border Radius in Default Dialog defaults to 100 and radius received via param was not used at all. 
This PR changes that: If user specifies a value, then that value is used. Otherwise, 100 will be used as always.

Every PR must update the corresponding documentation in the `code`, and also the readme in english with the following changes.

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
