### PR TITLE
Sm refactor

### DIFF
--- a/example/lib/pages/home/presentation/controllers/home_controller.dart
+++ b/example/lib/pages/home/presentation/controllers/home_controller.dart
@@ -3,7 +3,7 @@ import 'package:get/get.dart';
 import '../../domain/adapters/repository_adapter.dart';
 import '../../domain/entity/cases_model.dart';
 
-class HomeController extends SuperController<CasesModel> {
+class HomeController extends StateController<CasesModel> {
   HomeController({required this.homeRepository});
 
   final IHomeRepository homeRepository;
@@ -13,7 +13,7 @@ class HomeController extends SuperController<CasesModel> {
     super.onInit();
 
     //Loading, Success, Error handle with 1 line of code
-    append(() => homeRepository.getCases);
+    listenFuture(() => homeRepository.getCases);
   }
 
   Country getCountryById(String id) {
@@ -23,62 +23,5 @@ class HomeController extends SuperController<CasesModel> {
     }
 
     return state.countries.first;
-  }
-
-  @override
-  void onReady() {
-    print('The build method is done. '
-        'Your controller is ready to call dialogs and snackbars');
-    super.onReady();
-  }
-
-  @override
-  void onClose() {
-    print('onClose called');
-    super.onClose();
-  }
-
-  @override
-  void didChangeMetrics() {
-    print('the window size did change');
-    super.didChangeMetrics();
-  }
-
-  @override
-  void didChangePlatformBrightness() {
-    print('platform change ThemeMode');
-    super.didChangePlatformBrightness();
-  }
-
-  @override
-  Future<bool> didPushRoute(String route) {
-    print('the route $route will be open');
-    return super.didPushRoute(route);
-  }
-
-  @override
-  Future<bool> didPopRoute() {
-    print('the current route will be closed');
-    return super.didPopRoute();
-  }
-
-  @override
-  void onDetached() {
-    print('onDetached called');
-  }
-
-  @override
-  void onInactive() {
-    print('onInative called');
-  }
-
-  @override
-  void onPaused() {
-    print('onPaused called');
-  }
-
-  @override
-  void onResumed() {
-    print('onResumed called');
   }
 }

--- a/example/lib/pages/home/presentation/controllers/home_controller.dart
+++ b/example/lib/pages/home/presentation/controllers/home_controller.dart
@@ -11,17 +11,12 @@ class HomeController extends StateController<CasesModel> {
   @override
   void onInit() {
     super.onInit();
-
     //Loading, Success, Error handle with 1 line of code
-    listenFuture(() => homeRepository.getCases);
+    futurize(() => homeRepository.getCases);
   }
 
   Country getCountryById(String id) {
     final index = int.tryParse(id);
-    if (index != null) {
-      return state.countries[index];
-    }
-
-    return state.countries.first;
+    return index != null ? state.countries[index] : state.countries.first;
   }
 }

--- a/example/test/main_test.dart
+++ b/example/test/main_test.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -11,28 +10,29 @@ import 'package:get_demo/pages/home/presentation/controllers/home_controller.dar
 // import 'package:get_test/get_test.dart';
 import 'package:matcher/matcher.dart' as m;
 
-class MockRepository implements IHomeRepository {
+class MockRepositorySuccess implements IHomeRepository {
   @override
   Future<CasesModel> getCases() async {
-    await Future.delayed(Duration(milliseconds: 100));
+    return CasesModel(
+      global: Global(
+          totalDeaths: 100,
+          totalConfirmed: 200,
+          date: DateTime.now(),
+          newConfirmed: 0,
+          newDeaths: 0,
+          newRecovered: 0,
+          totalRecovered: 0),
+      countries: [],
+      date: DateTime.now(),
+      id: '',
+      message: '',
+    );
+  }
+}
 
-    if (Random().nextBool()) {
-      return CasesModel(
-        global: Global(
-            totalDeaths: 100,
-            totalConfirmed: 200,
-            date: DateTime.now(),
-            newConfirmed: 0,
-            newDeaths: 0,
-            newRecovered: 0,
-            totalRecovered: 0),
-        countries: [],
-        date: DateTime.now(),
-        id: '',
-        message: '',
-      );
-    }
-
+class MockRepositoryFailure implements IHomeRepository {
+  @override
+  Future<CasesModel> getCases() async {
     return Future<CasesModel>.error('error');
   }
 }
@@ -41,28 +41,18 @@ void main() {
   WidgetsFlutterBinding.ensureInitialized();
   setUpAll(() => HttpOverrides.global = null);
   final binding = BindingsBuilder(() {
-    Get.lazyPut<IHomeRepository>(() => MockRepository());
+    Get.lazyPut<IHomeRepository>(() => MockRepositorySuccess());
     Get.lazyPut<HomeController>(
-        () => HomeController(homeRepository: Get.find()));
+      () => HomeController(homeRepository: Get.find()),
+    );
   });
 
-  test('Test Binding', () {
-    expect(Get.isPrepared<HomeController>(), false);
-    expect(Get.isPrepared<IHomeRepository>(), false);
-
-    /// test you Binding class with BindingsBuilder
-    binding.builder();
-
-    expect(Get.isPrepared<HomeController>(), true);
-    expect(Get.isPrepared<IHomeRepository>(), true);
-
-    Get.reset();
-  });
   test('Test Controller', () async {
     /// Controller can't be on memory
-    expect(() => Get.find<HomeController>(), throwsA(m.TypeMatcher<String>()));
+    expect(() => Get.find<HomeController>(tag: 'success'),
+        throwsA(m.TypeMatcher<String>()));
 
-    /// build Binding
+    /// binding will put the controller on memory
     binding.builder();
 
     /// recover your controller
@@ -77,24 +67,15 @@ void main() {
     /// await time request
     await Future.delayed(Duration(milliseconds: 100));
 
-    if (controller.status.isError) {
-      expect(controller.state, null);
-    }
+    /// test if status is success
+    expect(controller.status.isSuccess, true);
+    expect(controller.state.global.totalDeaths, 100);
+    expect(controller.state.global.totalConfirmed, 200);
 
-    if (controller.status.isSuccess) {
-      expect(controller.state.global.totalDeaths, 100);
-      expect(controller.state.global.totalConfirmed, 200);
-    }
-  });
-
-  test('ever', () async {
-    final count = ''.obs;
-    var result = '';
-    ever<String>(count, (value) {
-      result = value;
-    });
-    count.value = '1';
-    expect('1', result);
+    /// test if status is error
+    Get.lazyReplace<IHomeRepository>(() => MockRepositoryFailure());
+    expect(controller.status.isError, true);
+    expect(controller.state, null);
   });
 
   /// Tests with GetTests
@@ -150,27 +131,4 @@ void main() {
       print('onClose');
     },
   );*/
-}
-
-class Controller extends GetxController {
-  final count = 0.obs;
-  void increment() => count.value++;
-
-  @override
-  void onInit() {
-    print('inittt');
-    super.onInit();
-  }
-
-  @override
-  void onReady() {
-    print('onReady');
-    super.onReady();
-  }
-
-  @override
-  void onClose() {
-    super.onClose();
-    print('onClose');
-  }
 }

--- a/example_nav2/ios/Flutter/AppFrameworkInfo.plist
+++ b/example_nav2/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/example_nav2/ios/Runner.xcodeproj/project.pbxproj
+++ b/example_nav2/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -127,7 +127,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/example_nav2/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example_nav2/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example_nav2/lib/main.dart
+++ b/example_nav2/lib/main.dart
@@ -28,7 +28,7 @@ class Home extends ObxStatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            SimpleBuilder(builder: (context) {
+            Observer(builder: (context) {
               print('builder');
               return Text(
                 '${controller.count.value}',

--- a/example_nav2/lib/main.dart
+++ b/example_nav2/lib/main.dart
@@ -1,27 +1,53 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-import 'app/routes/app_pages.dart';
-import 'services/auth_service.dart';
-
 void main() {
   runApp(
-    GetMaterialApp.router(
-      title: "Application",
-      initialBinding: BindingsBuilder(
-        () {
-          Get.put(AuthService());
-        },
-      ),
-      getPages: AppPages.routes,
-      // routeInformationParser: GetInformationParser(
-      //     // initialRoute: Routes.HOME,
-      //     ),
-      // routerDelegate: GetDelegate(
-      //   backButtonPopMode: PopMode.History,
-      //   preventDuplicateHandlingMode:
-      //       PreventDuplicateHandlingMode.ReorderRoutes,
-      // ),
+    GetMaterialApp(
+      home: Home(),
     ),
   );
+}
+
+class Controller extends GetxController {
+  final count = 0.reactive;
+  void increment() {
+    count.value++;
+    update();
+  }
+}
+
+class Home extends ObxStatelessWidget {
+  const Home({Key? key}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.put(Controller());
+    return Scaffold(
+      appBar: AppBar(title: Text("counter")),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            SimpleBuilder(builder: (context) {
+              print('builder');
+              return Text(
+                '${controller.count.value}',
+                style: TextStyle(fontSize: 30),
+              );
+            }),
+            // ElevatedButton(
+            //   child: Text('Next Route'),
+            //   onPressed: () {
+            //     Get.to(() => Second());
+            //   },
+            // ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        child: Icon(Icons.add),
+        onPressed: controller.increment,
+      ),
+    );
+  }
 }

--- a/example_nav2/lib/main.dart
+++ b/example_nav2/lib/main.dart
@@ -1,53 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
+import 'app/routes/app_pages.dart';
+import 'services/auth_service.dart';
+
 void main() {
   runApp(
-    GetMaterialApp(
-      home: Home(),
+    GetMaterialApp.router(
+      title: "Application",
+      initialBinding: BindingsBuilder(
+        () {
+          Get.put(AuthService());
+        },
+      ),
+      getPages: AppPages.routes,
+      // routeInformationParser: GetInformationParser(
+      //     // initialRoute: Routes.HOME,
+      //     ),
+      // routerDelegate: GetDelegate(
+      //   backButtonPopMode: PopMode.History,
+      //   preventDuplicateHandlingMode:
+      //       PreventDuplicateHandlingMode.ReorderRoutes,
+      // ),
     ),
   );
-}
-
-class Controller extends GetxController {
-  final count = 0.reactive;
-  void increment() {
-    count.value++;
-    update();
-  }
-}
-
-class Home extends ObxStatelessWidget {
-  const Home({Key? key}) : super(key: key);
-  @override
-  Widget build(BuildContext context) {
-    final controller = Get.put(Controller());
-    return Scaffold(
-      appBar: AppBar(title: Text("counter")),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Observer(builder: (context) {
-              print('builder');
-              return Text(
-                '${controller.count.value}',
-                style: TextStyle(fontSize: 30),
-              );
-            }),
-            // ElevatedButton(
-            //   child: Text('Next Route'),
-            //   onPressed: () {
-            //     Get.to(() => Second());
-            //   },
-            // ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        child: Icon(Icons.add),
-        onPressed: controller.increment,
-      ),
-    );
-  }
 }

--- a/lib/get_navigation/src/nav2/get_router_delegate.dart
+++ b/lib/get_navigation/src/nav2/get_router_delegate.dart
@@ -6,7 +6,8 @@ import 'package:flutter/material.dart';
 import '../../../get.dart';
 import '../../../get_state_manager/src/simple/list_notifier.dart';
 
-class GetDelegate extends RouterDelegate<GetNavConfig> with ListNotifierMixin {
+class GetDelegate extends RouterDelegate<GetNavConfig>
+    with ListNotifierSingleMixin {
   final List<GetNavConfig> history = <GetNavConfig>[];
   final PopMode backButtonPopMode;
   final PreventDuplicateHandlingMode preventDuplicateHandlingMode;

--- a/lib/get_rx/src/rx_stream/get_stream.dart
+++ b/lib/get_rx/src/rx_stream/get_stream.dart
@@ -1,228 +1,229 @@
-part of rx_stream;
+// part of rx_stream;
 
-/// [GetStream] is the lightest and most performative way of working
-/// with events at Dart. You sintaxe is like StreamController, but it works
-/// with simple callbacks. In this way, every event calls only one function.
-/// There is no buffering, to very low memory consumption.
-/// event [add] will add a object to stream. [addError] will add a error
-/// to stream. [listen] is a very light StreamSubscription interface.
-/// Is possible take the last value with [value] property.
-class GetStream<T> {
-  void Function()? onListen;
-  void Function()? onPause;
-  void Function()? onResume;
-  FutureOr<void> Function()? onCancel;
+// /// [GetStream] is the lightest and most performative way of working
+// /// with events at Dart. You sintaxe is like StreamController, but it works
+// /// with simple callbacks. In this way, every event calls only one function.
+// /// There is no buffering, to very low memory consumption.
+// /// event [add] will add a object to stream. [addError] will add a error
+// /// to stream. [listen] is a very light StreamSubscription interface.
+// /// Is possible take the last value with [value] property.
+// class GetStream<T> {
+//   void Function()? onListen;
+//   void Function()? onPause;
+//   void Function()? onResume;
+//   FutureOr<void> Function()? onCancel;
 
-  GetStream({this.onListen, this.onPause, this.onResume, this.onCancel});
+//   GetStream({this.onListen, this.onPause, this.onResume, this.onCancel});
 
-  factory GetStream.fromValue(T value,
-      {Function()? onListen,
-      Function()? onPause,
-      Function()? onResume,
-      FutureOr<void> Function()? onCancel}) {
-    final valuedStream = GetStream<T>(
-        onListen: onListen,
-        onPause: onPause,
-        onResume: onResume,
-        onCancel: onCancel)
-      .._value = value;
+//   factory GetStream.fromValue(T value,
+//       {Function()? onListen,
+//       Function()? onPause,
+//       Function()? onResume,
+//       FutureOr<void> Function()? onCancel}) {
+//     final valuedStream = GetStream<T>(
+//         onListen: onListen,
+//         onPause: onPause,
+//         onResume: onResume,
+//         onCancel: onCancel)
+//       .._value = value;
 
-    return valuedStream;
-  }
+//     return valuedStream;
+//   }
 
-  List<LightSubscription<T>>? _onData = <LightSubscription<T>>[];
+//   List<LightSubscription<T>>? _onData = <LightSubscription<T>>[];
 
-  bool? _isBusy = false;
+//   bool? _isBusy = false;
 
-  FutureOr<bool?> removeSubscription(LightSubscription<T> subs) async {
-    if (!_isBusy!) {
-      return _onData!.remove(subs);
-    } else {
-      await Future.delayed(Duration.zero);
-      return _onData?.remove(subs);
-    }
-  }
+//   FutureOr<bool?> removeSubscription(LightSubscription<T> subs) async {
+//     if (!_isBusy!) {
+//       return _onData!.remove(subs);
+//     } else {
+//       await Future.delayed(Duration.zero);
+//       return _onData?.remove(subs);
+//     }
+//   }
 
-  FutureOr<void> addSubscription(LightSubscription<T> subs) async {
-    if (!_isBusy!) {
-      return _onData!.add(subs);
-    } else {
-      await Future.delayed(Duration.zero);
-      return _onData!.add(subs);
-    }
-  }
+//   FutureOr<void> addSubscription(LightSubscription<T> subs) async {
+//     if (!_isBusy!) {
+//       return _onData!.add(subs);
+//     } else {
+//       await Future.delayed(Duration.zero);
+//       return _onData!.add(subs);
+//     }
+//   }
 
-  int? get length => _onData?.length;
+//   int? get length => _onData?.length;
 
-  bool get hasListeners => _onData!.isNotEmpty;
+//   bool get hasListeners => _onData!.isNotEmpty;
 
-  void _notifyData(T data) {
-    _isBusy = true;
-    for (final item in _onData!) {
-      if (!item.isPaused) {
-        item._data?.call(data);
-      }
-    }
-    _isBusy = false;
-  }
+//   void _notifyData(T data) {
+//     _isBusy = true;
+//     for (final item in _onData!) {
+//       if (!item.isPaused) {
+//         item._data?.call(data);
+//       }
+//     }
+//     _isBusy = false;
+//   }
 
-  void _notifyError(Object error, [StackTrace? stackTrace]) {
-    assert(!isClosed, 'You cannot add errors to a closed stream.');
-    _isBusy = true;
-    var itemsToRemove = <LightSubscription<T>>[];
-    for (final item in _onData!) {
-      if (!item.isPaused) {
-        if (stackTrace != null) {
-          item._onError?.call(error, stackTrace);
-        } else {
-          item._onError?.call(error);
-        }
+//   void _notifyError(Object error, [StackTrace? stackTrace]) {
+//     assert(!isClosed, 'You cannot add errors to a closed stream.');
+//     _isBusy = true;
+//     var itemsToRemove = <LightSubscription<T>>[];
+//     for (final item in _onData!) {
+//       if (!item.isPaused) {
+//         if (stackTrace != null) {
+//           item._onError?.call(error, stackTrace);
+//         } else {
+//           item._onError?.call(error);
+//         }
 
-        if (item.cancelOnError ?? false) {
-          //item.cancel?.call();
-          itemsToRemove.add(item);
-          item.pause();
-          item._onDone?.call();
-        }
-      }
-    }
-    for (final item in itemsToRemove) {
-      _onData!.remove(item);
-    }
-    _isBusy = false;
-  }
+//         if (item.cancelOnError ?? false) {
+//           //item.cancel?.call();
+//           itemsToRemove.add(item);
+//           item.pause();
+//           item._onDone?.call();
+//         }
+//       }
+//     }
+//     for (final item in itemsToRemove) {
+//       _onData!.remove(item);
+//     }
+//     _isBusy = false;
+//   }
 
-  void _notifyDone() {
-    assert(!isClosed, 'You cannot close a closed stream.');
-    _isBusy = true;
-    for (final item in _onData!) {
-      if (!item.isPaused) {
-        item._onDone?.call();
-      }
-    }
-    _isBusy = false;
-  }
+//   void _notifyDone() {
+//     assert(!isClosed, 'You cannot close a closed stream.');
+//     _isBusy = true;
+//     for (final item in _onData!) {
+//       if (!item.isPaused) {
+//         item._onDone?.call();
+//       }
+//     }
+//     _isBusy = false;
+//   }
 
-  late T _value;
+//   late T _value;
 
-  T get value {
-    // RxInterface.proxy?.addListener(this);
-    return _value;
-  }
+//   T get value {
+//     // RxInterface.proxy?.addListener(this);
+//     return _value;
+//   }
 
-  void add(T event) {
-    assert(!isClosed, 'You cannot add event to closed Stream');
-    _value = event;
-    _notifyData(event);
-  }
+//   void add(T event) {
+//     assert(!isClosed, 'You cannot add event to closed Stream');
+//     _value = event;
+//     _notifyData(event);
+//   }
 
-  bool get isClosed => _onData == null;
+//   bool get isClosed => _onData == null;
 
-  void addError(Object error, [StackTrace? stackTrace]) {
-    assert(!isClosed, 'You cannot add error to closed Stream');
-    _notifyError(error, stackTrace);
-  }
+//   void addError(Object error, [StackTrace? stackTrace]) {
+//     assert(!isClosed, 'You cannot add error to closed Stream');
+//     _notifyError(error, stackTrace);
+//   }
 
-  void close() {
-    assert(!isClosed, 'You cannot close a closed Stream');
-    _notifyDone();
-    _onData = null;
-    _isBusy = null;
-    //  _value = null;
-  }
+//   void close() {
+//     assert(!isClosed, 'You cannot close a closed Stream');
+//     _notifyDone();
+//     _onData = null;
+//     _isBusy = null;
+//     //  _value = null;
+//   }
 
-  LightSubscription<T> listen(void Function(T event) onData,
-      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
-    final subs = LightSubscription<T>(
-      removeSubscription,
-      onPause: onPause,
-      onResume: onResume,
-      onCancel: onCancel,
-    )
-      ..onData(onData)
-      ..onError(onError)
-      ..onDone(onDone)
-      ..cancelOnError = cancelOnError;
-    addSubscription(subs);
-    onListen?.call();
-    return subs;
-  }
+//   LightSubscription<T> listen(void Function(T event) onData,
+//       {Function? onError, void Function()? onDone, bool? cancelOnError}) {
+//     final subs = LightSubscription<T>(
+//       removeSubscription,
+//       onPause: onPause,
+//       onResume: onResume,
+//       onCancel: onCancel,
+//     )
+//       ..onData(onData)
+//       ..onError(onError)
+//       ..onDone(onDone)
+//       ..cancelOnError = cancelOnError;
+//     addSubscription(subs);
+//     onListen?.call();
+//     return subs;
+//   }
 
-  Stream<T> get stream =>
-      GetStreamTransformation(addSubscription, removeSubscription);
-}
+//   Stream<T> get stream =>
+//       GetStreamTransformation(addSubscription, removeSubscription);
+// }
 
-class LightSubscription<T> extends StreamSubscription<T> {
-  final RemoveSubscription<T> _removeSubscription;
-  LightSubscription(this._removeSubscription,
-      {this.onPause, this.onResume, this.onCancel});
-  final void Function()? onPause;
-  final void Function()? onResume;
-  final FutureOr<void> Function()? onCancel;
+// class LightSubscription<T> extends StreamSubscription<T> {
+//   final RemoveSubscription<T> _removeSubscription;
+//   LightSubscription(this._removeSubscription,
+//       {this.onPause, this.onResume, this.onCancel});
+//   final void Function()? onPause;
+//   final void Function()? onResume;
+//   final FutureOr<void> Function()? onCancel;
 
-  bool? cancelOnError = false;
+//   bool? cancelOnError = false;
 
-  @override
-  Future<void> cancel() {
-    _removeSubscription(this);
-    onCancel?.call();
-    return Future.value();
-  }
+//   @override
+//   Future<void> cancel() {
+//     _removeSubscription(this);
+//     onCancel?.call();
+//     return Future.value();
+//   }
 
-  OnData<T>? _data;
+//   OnData<T>? _data;
 
-  Function? _onError;
+//   Function? _onError;
 
-  Callback? _onDone;
+//   Callback? _onDone;
 
-  bool _isPaused = false;
+//   bool _isPaused = false;
 
-  @override
-  void onData(OnData<T>? handleData) => _data = handleData;
+//   @override
+//   void onData(OnData<T>? handleData) => _data = handleData;
 
-  @override
-  void onError(Function? handleError) => _onError = handleError;
+//   @override
+//   void onError(Function? handleError) => _onError = handleError;
 
-  @override
-  void onDone(Callback? handleDone) => _onDone = handleDone;
+//   @override
+//   void onDone(Callback? handleDone) => _onDone = handleDone;
 
-  @override
-  void pause([Future<void>? resumeSignal]) {
-    _isPaused = true;
-    onPause?.call();
-  }
+//   @override
+//   void pause([Future<void>? resumeSignal]) {
+//     _isPaused = true;
+//     onPause?.call();
+//   }
 
-  @override
-  void resume() {
-    _isPaused = false;
-    onResume?.call();
-  }
+//   @override
+//   void resume() {
+//     _isPaused = false;
+//     onResume?.call();
+//   }
 
-  @override
-  bool get isPaused => _isPaused;
+//   @override
+//   bool get isPaused => _isPaused;
 
-  @override
-  Future<E> asFuture<E>([E? futureValue]) => Future.value(futureValue);
-}
+//   @override
+//   Future<E> asFuture<E>([E? futureValue]) => Future.value(futureValue);
+// }
 
-class GetStreamTransformation<T> extends Stream<T> {
-  final AddSubscription<T> _addSubscription;
-  final RemoveSubscription<T> _removeSubscription;
-  GetStreamTransformation(this._addSubscription, this._removeSubscription);
+// class GetStreamTransformation<T> extends Stream<T> {
+//   final AddSubscription<T> _addSubscription;
+//   final RemoveSubscription<T> _removeSubscription;
+//   GetStreamTransformation(this._addSubscription, this._removeSubscription);
 
-  @override
-  LightSubscription<T> listen(void Function(T event)? onData,
-      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
-    final subs = LightSubscription<T>(_removeSubscription)
-      ..onData(onData)
-      ..onError(onError)
-      ..onDone(onDone);
-    _addSubscription(subs);
-    return subs;
-  }
-}
+//   @override
+//   LightSubscription<T> listen(void Function(T event)? onData,
+//       {Function? onError, void Function()? onDone, bool? cancelOnError}) {
+//     final subs = LightSubscription<T>(_removeSubscription)
+//       ..onData(onData)
+//       ..onError(onError)
+//       ..onDone(onDone);
+//     _addSubscription(subs);
+//     return subs;
+//   }
+// }
 
-typedef RemoveSubscription<T> = FutureOr<bool?> Function(
-    LightSubscription<T> subs);
+// typedef RemoveSubscription<T> = FutureOr<bool?> Function(
+//     LightSubscription<T> subs);
 
-typedef AddSubscription<T> = FutureOr<void> Function(LightSubscription<T> subs);
+// typedef AddSubscription<T> = 
+//FutureOr<void> Function(LightSubscription<T> subs);

--- a/lib/get_rx/src/rx_stream/get_stream.dart
+++ b/lib/get_rx/src/rx_stream/get_stream.dart
@@ -106,7 +106,7 @@ class GetStream<T> {
   late T _value;
 
   T get value {
-    RxInterface.proxy?.addListener(this);
+    // RxInterface.proxy?.addListener(this);
     return _value;
   }
 

--- a/lib/get_rx/src/rx_stream/rx_stream.dart
+++ b/lib/get_rx/src/rx_stream/rx_stream.dart
@@ -3,7 +3,6 @@ library rx_stream;
 import 'dart:async';
 
 import '../rx_typedefs/rx_typedefs.dart';
-import '../rx_types/rx_types.dart';
 
-part 'get_stream.dart';
+//part 'get_stream.dart';
 part 'mini_stream.dart';

--- a/lib/get_rx/src/rx_types/rx_core/rx_interface.dart
+++ b/lib/get_rx/src/rx_types/rx_core/rx_interface.dart
@@ -5,12 +5,10 @@ part of rx_types;
 /// This interface is the contract that _RxImpl]<T> uses in all it's
 /// subclass.
 abstract class RxInterface<T> {
-  static RxInterface? proxy;
-
-  bool get canUpdate;
+  //bool get canUpdate;
 
   /// Adds a listener to stream
-  void addListener(GetStream<T> rxGetx);
+  void addListener(VoidCallback listener);
 
   /// Close the Rx Variable
   void close();
@@ -20,13 +18,24 @@ abstract class RxInterface<T> {
       {Function? onError, void Function()? onDone, bool? cancelOnError});
 
   /// Avoids an unsafe usage of the `proxy`
-  static T notifyChildren<T>(RxNotifier observer, ValueGetter<T> builder) {
-    final _observer = RxInterface.proxy;
-    RxInterface.proxy = observer;
-    final result = builder();
-    if (!observer.canUpdate) {
-      RxInterface.proxy = _observer;
-      throw """
+  // static T notifyChildren<T>(RxNotifier observer, ValueGetter<T> builder) {
+  //   final _observer = RxInterface.proxy;
+  //   RxInterface.proxy = observer;
+  //   final result = builder();
+  //   if (!observer.canUpdate) {
+  //     RxInterface.proxy = _observer;
+  //     throw ObxError();
+  //   }
+  //   RxInterface.proxy = _observer;
+  //   return result;
+  // }
+}
+
+class ObxError {
+  const ObxError();
+  @override
+  String toString() {
+    return """
       [Get] the improper use of a GetX has been detected. 
       You should only use GetX or Obx for the specific widget that will be updated.
       If you are seeing this error, you probably did not insert any observable variables into GetX/Obx 
@@ -34,8 +43,5 @@ abstract class RxInterface<T> {
       (example: GetX => HeavyWidget => variableObservable).
       If you need to update a parent widget and a child widget, wrap each one in an Obx/GetX.
       """;
-    }
-    RxInterface.proxy = _observer;
-    return result;
   }
 }

--- a/lib/get_rx/src/rx_types/rx_iterables/rx_list.dart
+++ b/lib/get_rx/src/rx_types/rx_iterables/rx_list.dart
@@ -1,12 +1,9 @@
 part of rx_types;
 
 /// Create a list similar to `List<T>`
-class RxList<E> extends ListMixin<E>
-    with NotifyManager<List<E>>, RxObjectMixin<List<E>>
-    implements RxInterface<List<E>> {
-  RxList([List<E> initial = const []]) {
-    subject = GetStream.fromValue(List.from(initial));
-  }
+class RxList<E> extends GetListenable<List<E>>
+    with ListMixin<E>, RxObjectMixin<List<E>> {
+  RxList([List<E> initial = const []]) : super(initial);
 
   factory RxList.filled(int length, E fill, {bool growable = false}) {
     return RxList(List.filled(length, fill, growable: growable));
@@ -87,12 +84,12 @@ class RxList<E> extends ListMixin<E>
   @override
   int get length => value.length;
 
-  @override
-  @protected
-  List<E> get value {
-    RxInterface.proxy?.addListener(subject);
-    return subject.value;
-  }
+  // @override
+  // @protected
+  // List<E> get value {
+  //   RxInterface.proxy?.addListener(subject);
+  //   return subject.value;
+  // }
 
   @override
   set length(int newLength) {

--- a/lib/get_rx/src/rx_types/rx_iterables/rx_map.dart
+++ b/lib/get_rx/src/rx_types/rx_iterables/rx_map.dart
@@ -1,11 +1,8 @@
 part of rx_types;
 
-class RxMap<K, V> extends MapMixin<K, V>
-    with NotifyManager<Map<K, V>>, RxObjectMixin<Map<K, V>>
-    implements RxInterface<Map<K, V>> {
-  RxMap([Map<K, V> initial = const {}]) {
-    subject = GetStream.fromValue(Map.from(initial));
-  }
+class RxMap<K, V> extends GetListenable<Map<K, V>>
+    with MapMixin<K, V>, RxObjectMixin<Map<K, V>> {
+  RxMap([Map<K, V> initial = const {}]) : super(initial);
 
   factory RxMap.from(Map<K, V> other) {
     return RxMap(Map.from(other));
@@ -53,13 +50,13 @@ class RxMap<K, V> extends MapMixin<K, V>
     return val;
   }
 
-  @override
-  @protected
-  Map<K, V> get value {
-    return subject.value;
-    // RxInterface.proxy?.addListener(subject);
-    // return _value;
-  }
+  // @override
+  // @protected
+  // Map<K, V> get value {
+  //   return subject.value;
+  //   // RxInterface.proxy?.addListener(subject);
+  //   // return _value;
+  // }
 }
 
 extension MapExtension<K, V> on Map<K, V> {

--- a/lib/get_rx/src/rx_types/rx_iterables/rx_map.dart
+++ b/lib/get_rx/src/rx_types/rx_iterables/rx_map.dart
@@ -96,6 +96,7 @@ extension MapExtension<K, V> on Map<K, V> {
       final map = (this as RxMap);
       if (map.value == val) return;
       map.value = val;
+      // ignore: invalid_use_of_protected_member
       map.refresh();
     } else {
       if (this == val) return;

--- a/lib/get_rx/src/rx_types/rx_iterables/rx_set.dart
+++ b/lib/get_rx/src/rx_types/rx_iterables/rx_set.dart
@@ -1,11 +1,8 @@
 part of rx_types;
 
-class RxSet<E> extends SetMixin<E>
-    with NotifyManager<Set<E>>, RxObjectMixin<Set<E>>
-    implements RxInterface<Set<E>> {
-  RxSet([Set<E> initial = const {}]) {
-    subject = GetStream.fromValue(Set.from(initial));
-  }
+class RxSet<E> extends GetListenable<Set<E>>
+    with SetMixin<E>, RxObjectMixin<Set<E>> {
+  RxSet([Set<E> initial = const {}]) : super(initial);
 
   /// Special override to push() element(s) in a reactive way
   /// inside the List,
@@ -20,13 +17,13 @@ class RxSet<E> extends SetMixin<E>
     refresh();
   }
 
-  @override
-  @protected
-  Set<E> get value {
-    return subject.value;
-    // RxInterface.proxy?.addListener(subject);
-    // return _value;
-  }
+  // @override
+  // @protected
+  // Set<E> get value {
+  //   return subject.value;
+  //   // RxInterface.proxy?.addListener(subject);
+  //   // return _value;
+  // }
 
   @override
   @protected

--- a/lib/get_rx/src/rx_types/rx_types.dart
+++ b/lib/get_rx/src/rx_types/rx_types.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
+import 'package:get/get_state_manager/src/rx_flutter/rx_notifier.dart';
 import 'package:get/get_state_manager/src/simple/list_notifier.dart';
 
 import '../rx_stream/rx_stream.dart';

--- a/lib/get_rx/src/rx_types/rx_types.dart
+++ b/lib/get_rx/src/rx_types/rx_types.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
+import 'package:get/get_state_manager/src/simple/list_notifier.dart';
 
 import '../rx_stream/rx_stream.dart';
 import '../rx_typedefs/rx_typedefs.dart';

--- a/lib/get_rx/src/rx_types/rx_types.dart
+++ b/lib/get_rx/src/rx_types/rx_types.dart
@@ -4,10 +4,8 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
-import 'package:get/get_state_manager/src/rx_flutter/rx_notifier.dart';
-import 'package:get/get_state_manager/src/simple/list_notifier.dart';
 
-import '../rx_stream/rx_stream.dart';
+import '../../../get_state_manager/src/rx_flutter/rx_notifier.dart';
 import '../rx_typedefs/rx_typedefs.dart';
 
 part 'rx_core/rx_impl.dart';

--- a/lib/get_rx/src/rx_workers/rx_workers.dart
+++ b/lib/get_rx/src/rx_workers/rx_workers.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import '../../../get_core/get_core.dart';
+import '../../../get_state_manager/src/rx_flutter/rx_notifier.dart';
 import '../rx_types/rx_types.dart';
 import 'utils/debouncer.dart';
 
@@ -57,7 +58,7 @@ class Workers {
 /// }
 /// ```
 Worker ever<T>(
-  RxInterface<T> listener,
+  GetListenable<T> listener,
   WorkerCallback<T> callback, {
   dynamic condition = true,
   Function? onError,
@@ -132,7 +133,7 @@ Worker everAll(
 /// }
 ///```
 Worker once<T>(
-  RxInterface<T> listener,
+  GetListenable<T> listener,
   WorkerCallback<T> callback, {
   dynamic condition = true,
   Function? onError,
@@ -175,7 +176,7 @@ Worker once<T>(
 /// );
 /// ```
 Worker interval<T>(
-  RxInterface<T> listener,
+  GetListenable<T> listener,
   WorkerCallback<T> callback, {
   Duration time = const Duration(seconds: 1),
   dynamic condition = true,
@@ -219,7 +220,7 @@ Worker interval<T>(
 ///  }
 ///  ```
 Worker debounce<T>(
-  RxInterface<T> listener,
+  GetListenable<T> listener,
   WorkerCallback<T> callback, {
   Duration? time,
   Function? onError,

--- a/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
+++ b/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
@@ -5,7 +5,7 @@ import '../../../instance_manager.dart';
 import '../../get_state_manager.dart';
 import '../simple/list_notifier.dart';
 
-mixin StateMixin<T> on ListNotifierMixin {
+mixin StateMixin<T> on ListNotifier {
   late T _value;
   RxStatus? _status;
 
@@ -27,7 +27,7 @@ mixin StateMixin<T> on ListNotifierMixin {
   }
 
   RxStatus get status {
-    notifyChildrens();
+    reportRead();
     return _status ??= _status = RxStatus.loading();
   }
 
@@ -35,7 +35,7 @@ mixin StateMixin<T> on ListNotifierMixin {
 
   @protected
   T get value {
-    notifyChildrens();
+    reportRead();
     return _value;
   }
 
@@ -82,7 +82,7 @@ class Value<T> extends ListNotifier
 
   @override
   T get value {
-    notifyChildrens();
+    reportRead();
     return _value;
   }
 

--- a/lib/get_state_manager/src/rx_flutter/rx_obx_widget.dart
+++ b/lib/get_state_manager/src/rx_flutter/rx_obx_widget.dart
@@ -1,9 +1,7 @@
-import 'dart:async';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../../get_rx/src/rx_types/rx_types.dart';
+import '../simple/simple_builder.dart';
 
 typedef WidgetCallback = Widget Function();
 
@@ -12,48 +10,8 @@ typedef WidgetCallback = Widget Function();
 /// See also:
 /// - [Obx]
 /// - [ObxValue]
-abstract class ObxWidget extends StatefulWidget {
+abstract class ObxWidget extends ObxStatelessWidget {
   const ObxWidget({Key? key}) : super(key: key);
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties..add(ObjectFlagProperty<Function>.has('builder', build));
-  }
-
-  @override
-  _ObxState createState() => _ObxState();
-
-  @protected
-  Widget build();
-}
-
-class _ObxState extends State<ObxWidget> {
-  final _observer = RxNotifier();
-  late StreamSubscription subs;
-
-  @override
-  void initState() {
-    super.initState();
-    subs = _observer.subject.stream.listen(_updateTree, cancelOnError: false);
-  }
-
-  void _updateTree(_) {
-    if (mounted) {
-      setState(() {});
-    }
-  }
-
-  @override
-  void dispose() {
-    subs.cancel();
-    _observer.close();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) =>
-      RxInterface.notifyChildren(_observer, widget.build);
 }
 
 /// The simplest reactive widget in GetX.
@@ -69,7 +27,9 @@ class Obx extends ObxWidget {
   const Obx(this.builder);
 
   @override
-  Widget build() => builder();
+  Widget build(BuildContext context) {
+    return builder();
+  }
 }
 
 /// Similar to Obx, but manages a local state.
@@ -90,5 +50,5 @@ class ObxValue<T extends RxInterface> extends ObxWidget {
   const ObxValue(this.builder, this.data, {Key? key}) : super(key: key);
 
   @override
-  Widget build() => builder(data);
+  Widget build(BuildContext context) => builder(data);
 }

--- a/lib/get_state_manager/src/simple/get_controllers.dart
+++ b/lib/get_state_manager/src/simple/get_controllers.dart
@@ -72,6 +72,8 @@ mixin ScrollMixin on GetLifeCycleMixin {
 
 abstract class RxController with GetLifeCycleMixin {}
 
+abstract class StateController<T> extends GetxController with StateMixin<T> {}
+
 abstract class SuperController<T> extends FullLifeCycleController
     with FullLifeCycleMixin, StateMixin<T> {}
 

--- a/lib/get_state_manager/src/simple/get_controllers.dart
+++ b/lib/get_state_manager/src/simple/get_controllers.dart
@@ -6,8 +6,7 @@ import '../rx_flutter/rx_notifier.dart';
 import 'list_notifier.dart';
 
 // ignore: prefer_mixin
-abstract class GetxController extends Listenable
-    with GetLifeCycleMixin, ListNotifierMixin {
+abstract class GetxController extends ListNotifier with GetLifeCycleMixin {
   /// Rebuilds `GetBuilder` each time you call `update()`;
   /// Can take a List of [ids], that will only update the matching
   /// `GetBuilder( id: )`,

--- a/lib/get_state_manager/src/simple/list_notifier.dart
+++ b/lib/get_state_manager/src/simple/list_notifier.dart
@@ -1,6 +1,6 @@
 import 'dart:collection';
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/foundation.dart';
 
 // This callback remove the listener on addListener function
 typedef Disposer = void Function();
@@ -9,40 +9,48 @@ typedef Disposer = void Function();
 // if it brings overhead the extra call,
 typedef GetStateUpdate = void Function();
 
-class ListNotifier extends Listenable with ListNotifierMixin {}
+class ListNotifier extends Listenable
+    with ListNotifierSingleMixin, ListNotifierGroupMixin {}
 
-mixin ListNotifierMixin on Listenable {
+class ListNotifierSingle = ListNotifier with ListNotifierSingleMixin;
+
+class ListNotifierGroup = ListNotifier with ListNotifierGroupMixin;
+
+mixin ListNotifierSingleMixin on Listenable {
   List<GetStateUpdate?>? _updaters = <GetStateUpdate?>[];
 
-  HashMap<Object?, List<GetStateUpdate>>? _updatersGroupIds =
-      HashMap<Object?, List<GetStateUpdate>>();
+  @override
+  Disposer addListener(GetStateUpdate listener) {
+    assert(_debugAssertNotDisposed());
+    _updaters!.add(listener);
+    return () => _updaters!.remove(listener);
+  }
+
+  bool containsListener(GetStateUpdate listener) {
+    return _updaters?.contains(listener) ?? false;
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    assert(_debugAssertNotDisposed());
+    _updaters!.remove(listener);
+  }
 
   @protected
   void refresh() {
     assert(_debugAssertNotDisposed());
-
     _notifyUpdate();
+  }
+
+  @protected
+  void reportRead() {
+    TaskManager.instance.notify(this);
   }
 
   void _notifyUpdate() {
     for (var element in _updaters!) {
       element!();
     }
-  }
-
-  void _notifyIdUpdate(Object id) {
-    if (_updatersGroupIds!.containsKey(id)) {
-      final listGroup = _updatersGroupIds![id]!;
-      for (var item in listGroup) {
-        item();
-      }
-    }
-  }
-
-  @protected
-  void refreshGroup(Object id) {
-    assert(_debugAssertNotDisposed());
-    _notifyIdUpdate(id);
   }
 
   bool _debugAssertNotDisposed() {
@@ -56,59 +64,79 @@ mixin ListNotifierMixin on Listenable {
     return true;
   }
 
-  @protected
-  void notifyChildrens() {
-    TaskManager.instance.notify(_updaters);
-  }
-
-  bool get hasListeners {
-    assert(_debugAssertNotDisposed());
-    return _updaters!.isNotEmpty;
-  }
-
-  int get listeners {
+  int get listenersLength {
     assert(_debugAssertNotDisposed());
     return _updaters!.length;
-  }
-
-  @override
-  void removeListener(VoidCallback listener) {
-    assert(_debugAssertNotDisposed());
-    _updaters!.remove(listener);
-  }
-
-  void removeListenerId(Object id, VoidCallback listener) {
-    assert(_debugAssertNotDisposed());
-    if (_updatersGroupIds!.containsKey(id)) {
-      _updatersGroupIds![id]!.remove(listener);
-    }
-    _updaters!.remove(listener);
   }
 
   @mustCallSuper
   void dispose() {
     assert(_debugAssertNotDisposed());
     _updaters = null;
+  }
+}
+
+mixin ListNotifierGroupMixin on Listenable {
+  HashMap<Object?, ListNotifierSingleMixin>? _updatersGroupIds =
+      HashMap<Object?, ListNotifierSingleMixin>();
+
+  void _notifyGroupUpdate(Object id) {
+    if (_updatersGroupIds!.containsKey(id)) {
+      _updatersGroupIds![id]!._notifyUpdate();
+    }
+  }
+
+  @protected
+  void notifyGroupChildrens(Object id) {
+    assert(_debugAssertNotDisposed());
+    TaskManager.instance.notify(_updatersGroupIds![id]!);
+  }
+
+  bool containsId(Object id) {
+    return _updatersGroupIds?.containsKey(id) ?? false;
+  }
+
+  @protected
+  void refreshGroup(Object id) {
+    assert(_debugAssertNotDisposed());
+    _notifyGroupUpdate(id);
+  }
+
+  bool _debugAssertNotDisposed() {
+    assert(() {
+      if (_updatersGroupIds == null) {
+        throw FlutterError('''A $runtimeType was used after being disposed.\n
+'Once you have called dispose() on a $runtimeType, it can no longer be used.''');
+      }
+      return true;
+    }());
+    return true;
+  }
+
+  void removeListenerId(Object id, VoidCallback listener) {
+    assert(_debugAssertNotDisposed());
+    if (_updatersGroupIds!.containsKey(id)) {
+      _updatersGroupIds![id]!.removeListener(listener);
+    }
+  }
+
+  @mustCallSuper
+  void dispose() {
+    assert(_debugAssertNotDisposed());
+    _updatersGroupIds?.forEach((key, value) => value.dispose());
     _updatersGroupIds = null;
   }
 
-  @override
-  Disposer addListener(GetStateUpdate listener) {
-    assert(_debugAssertNotDisposed());
-    _updaters!.add(listener);
-    return () => _updaters!.remove(listener);
-  }
-
   Disposer addListenerId(Object? key, GetStateUpdate listener) {
-    _updatersGroupIds![key] ??= <GetStateUpdate>[];
-    _updatersGroupIds![key]!.add(listener);
-    return () => _updatersGroupIds![key]!.remove(listener);
+    _updatersGroupIds![key] ??= ListNotifierSingle();
+    return _updatersGroupIds![key]!.addListener(listener);
   }
 
   /// To dispose an [id] from future updates(), this ids are registered
   /// by `GetBuilder()` or similar, so is a way to unlink the state change with
   /// the Widget from the Controller.
   void disposeId(Object id) {
+    _updatersGroupIds?[id]?.dispose();
     _updatersGroupIds!.remove(id);
   }
 }
@@ -123,11 +151,18 @@ class TaskManager {
   GetStateUpdate? _setter;
   List<VoidCallback>? _remove;
 
-  void notify(List<GetStateUpdate?>? _updaters) {
-    if (_setter != null) {
-      if (!_updaters!.contains(_setter)) {
-        _updaters.add(_setter);
-        _remove!.add(() => _updaters.remove(_setter));
+  final listNotifier = ListNotifierGroup();
+
+  // void addElement(Object id, GetStateUpdate listener) {
+  //   _remove?.add(listNotifier.addListenerId(id, listener));
+  // }
+
+  void notify(ListNotifierSingleMixin _updaters) {
+    final listener = _setter;
+    if (listener != null) {
+      if (!_updaters.containsListener(listener)) {
+        _updaters.addListener(listener);
+        _remove?.add(() => _updaters.removeListener(listener));
       }
     }
   }

--- a/lib/get_state_manager/src/simple/list_notifier.dart
+++ b/lib/get_state_manager/src/simple/list_notifier.dart
@@ -176,7 +176,9 @@ class TaskManager {
       T Function() builder) {
     _remove = disposers;
     _setter = setState;
+
     final result = builder();
+    print(disposers.isEmpty);
     if (disposers.isEmpty) {
       throw ObxError();
     }

--- a/lib/get_state_manager/src/simple/simple_builder.dart
+++ b/lib/get_state_manager/src/simple/simple_builder.dart
@@ -78,10 +78,10 @@ class _ValueBuilderState<T> extends State<ValueBuilder<T?>> {
 class ObxElement = StatelessElement with ObserverComponent;
 
 // It's a experimental feature
-class SimpleBuilder extends ObxStatelessWidget {
+class Observer extends ObxStatelessWidget {
   final WidgetBuilder builder;
 
-  const SimpleBuilder({Key? key, required this.builder}) : super(key: key);
+  const Observer({Key? key, required this.builder}) : super(key: key);
 
   @override
   Widget build(BuildContext context) => builder(context);

--- a/test/benchmarks/benckmark_test.dart
+++ b/test/benchmarks/benckmark_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/state_manager.dart';
@@ -73,28 +74,28 @@ Future<int> stream() {
   return c.future;
 }
 
-Future<int> getStream() {
-  final c = Completer<int>();
+// Future<int> getStream() {
+//   final c = Completer<int>();
 
-  final value = GetStream<int>();
-  final timer = Stopwatch();
-  timer.start();
+//   final value = GetStream<int>();
+//   final timer = Stopwatch();
+//   timer.start();
 
-  value.listen((v) {
-    if (times == v) {
-      timer.stop();
-      print(
-          """$v listeners notified | [GET_STREAM] time: ${timer.elapsedMicroseconds}ms""");
-      c.complete(timer.elapsedMicroseconds);
-    }
-  });
+//   value.listen((v) {
+//     if (times == v) {
+//       timer.stop();
+//       print(
+//           """$v listeners notified | [GET_STREAM] time: ${timer.elapsedMicroseconds}ms""");
+//       c.complete(timer.elapsedMicroseconds);
+//     }
+//   });
 
-  for (var i = 0; i < times + 1; i++) {
-    value.add(i);
-  }
+//   for (var i = 0; i < times + 1; i++) {
+//     value.add(i);
+//   }
 
-  return c.future;
-}
+//   return c.future;
+// }
 
 Future<int> miniStream() {
   final c = Completer<int>();
@@ -157,7 +158,7 @@ GetValue is ${calculePercentage(dart, getx).round()}% faster than Default ValueN
     print('============================================');
     print('DART STREAM X GET_STREAM X GET_MINI_STREAM TEST');
     print('-----------');
-    var getx = await getStream();
+   // var getx = await getStream();
     var mini = await miniStream();
     var dart = await stream();
     print('-----------');
@@ -167,16 +168,16 @@ GetStream is ${calculePercentage(dart, mini).round()}% faster than Default Strea
 
     times = 30000;
     dart = await stream();
-    getx = await getStream();
+   // getx = await getStream();
     mini = await miniStream();
 
     times = 60000;
     dart = await stream();
-    getx = await getStream();
+  // getx = await getStream();
     mini = await miniStream();
     print('-----------');
     print('dart_stream delay $dart ms to made $times requests');
-    print('getx_stream delay $getx ms to made $times requests');
+   // print('getx_stream delay $getx ms to made $times requests');
     print('getx_mini_stream delay $mini ms to made $times requests');
     print('-----------');
     print('''


### PR DESCRIPTION
Our codebase was getting big, with two reactivity options. .obs to use streams and .reactive to use notifiers.
This PR unifies the api, allowing to use Streams, while making the api based on notifiers.

GetStream can now be safely removed, we don't need it anymore, because it was used to give streams more performance, and now using notifiers that outperform GetStreams (and normal streams accordingly).
The api was reduced, became more concise and readable, and now it is possible to create your own SM, with your own code, with your own widgets, using the pure api of Rx and Notifiers.

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [ ] All existing and new tests are passing.
