### PR TITLE
#2065: Add support for only language translations

### DIFF
--- a/lib/get_utils/src/extensions/internacionalization.dart
+++ b/lib/get_utils/src/extensions/internacionalization.dart
@@ -66,16 +66,26 @@ extension Trans on String {
   // Checks if there is a callback language in the absence of the specific
   // country, and if it contains that key.
   Map<String, String>? get _getSimilarLanguageTranslation {
+
+    var languageCode = Get.locale!.languageCode.split("_").first;
+
+
+
     final translationsWithNoCountry = Get.translations
         .map((key, value) => MapEntry(key.split("_").first, value));
+
+    if(Get.translations.containsKey(languageCode)){
+      translationsWithNoCountry[languageCode]!.addAll(Get.translations[languageCode]!);
+    }
+
     final containsKey = translationsWithNoCountry
-        .containsKey(Get.locale!.languageCode.split("_").first);
+        .containsKey(languageCode);
 
     if (!containsKey) {
       return null;
     }
 
-    return translationsWithNoCountry[Get.locale!.languageCode.split("_").first];
+    return translationsWithNoCountry[languageCode];
   }
 
   String get tr {

--- a/test/internationalization/internationalization_test.dart
+++ b/test/internationalization/internationalization_test.dart
@@ -31,5 +31,13 @@ void main() {
     expect('covid'.tr, 'Corona Virus');
     expect('total_confirmed'.tr, 'Total Confirmed');
     expect('total_deaths'.tr, 'Total Deaths');
+
+    Get.updateLocale(Locale('pt', 'PT'));
+
+    await tester.pumpAndSettle();
+
+    expect('covid'.tr, 'Corona Vírus only lang');
+    expect('total_confirmed'.tr, 'Total confirmado only lang');
+    expect('total_deaths'.tr, 'Total de mortes');
   });
 }

--- a/test/navigation/utils/wrapper.dart
+++ b/test/navigation/utils/wrapper.dart
@@ -64,6 +64,10 @@ class WrapperTranslations extends Translations {
           'total_confirmed': 'Total Confirmed',
           'total_deaths': 'Total Deaths',
         },
+        'pt': {
+          'covid': 'Corona Vírus only lang',
+          'total_confirmed': 'Total confirmado only lang',
+        },
         'pt_BR': {
           'covid': 'Corona Vírus',
           'total_confirmed': 'Total confirmado',


### PR DESCRIPTION
*Fixes #2065*

I'm updating the tranlsation service, so that, if we have a only language messages, and a language-country messages, when using a locale with no country matching, will use the language specific version.

Given the following messages:
```
'pt': {
          'covid': 'Corona Vírus only lang',
          'total_confirmed': 'Total confirmado only lang',
        },
'pt_BR': {
          'covid': 'Corona Vírus',
          'total_confirmed': 'Total confirmado',
          'total_deaths': 'Total de mortes',
        },
```

Translations will result in:

- Locale('pt','BR') -> 'covid' => 'Corona Vírus'
- Locale('pt','PT') -> 'covid' => 'Corona Vírus only lang'
- Locale('pt','BR') -> 'total_deaths' => 'Total de mortes'

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
