### PR TITLE
fix typo en_US state_managemet documentation

### DIFF
--- a/documentation/en_US/state_management.md
+++ b/documentation/en_US/state_management.md
@@ -385,7 +385,7 @@ Obx(()=> Text("Name ${user.value.name}: Age: ${user.value.age}"))
 user().name; // notice that is the user variable, not the class (variable has lowercase u)
 ```
 
-You don't have to work with sets if you don't want to. you can use the "assign 'and" assignAll "api.
+You don't have to work with sets if you don't want to. you can use the "assign" and "assignAll" api.
 The "assign" api will clear your list, and add a single object that you want to start there.
 The "assignAll" api will clear the existing list and add any iterable objects that you inject into it.
 
@@ -430,7 +430,7 @@ All workers (except `debounce` ) have a `condition` named parameter, which can b
 This `condition` defines when the `callback` function executes.
 
 All workers returns a `Worker` instance, that you can use to cancel ( via `dispose()` ) the worker.
- 
+
 
 * **`ever`**
 


### PR DESCRIPTION
[Updated] change "assign 'and" assignAll " into "assign" and "assignAll"
