### PR TITLE
Change bottom sheet default background color to use theme color

### DIFF
--- a/lib/get_navigation/src/extension_navigation.dart
+++ b/lib/get_navigation/src/extension_navigation.dart
@@ -45,7 +45,7 @@ extension ExtensionBottomSheet on GetInterface {
       barrierLabel: MaterialLocalizations.of(key.currentContext!)
           .modalBarrierDismissLabel,
 
-      backgroundColor: backgroundColor ?? Colors.transparent,
+      backgroundColor: backgroundColor,
       elevation: elevation,
       shape: shape,
       removeTop: ignoreSafeArea ?? true,

--- a/test/navigation/bottomsheet_test.dart
+++ b/test/navigation/bottomsheet_test.dart
@@ -71,4 +71,32 @@ void main() {
   //     );
   //   },
   // );
+
+  testWidgets("Get.bottomSheet background color theme test", (tester) async {
+    await tester.pumpWidget(
+      Wrapper(
+        child: Container(),
+        theme: ThemeData(
+          bottomSheetTheme: BottomSheetThemeData(backgroundColor: Colors.red),
+        ),
+      ),
+    );
+
+    Get.bottomSheet(Wrap(
+      children: <Widget>[
+        ListTile(
+          leading: Icon(Icons.music_note),
+          title: Text('Music'),
+          onTap: () {},
+        ),
+      ],
+    ));
+
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<BottomSheet>(find.byType(BottomSheet)).backgroundColor,
+      Colors.red,
+    );
+  });
 }

--- a/test/navigation/utils/wrapper.dart
+++ b/test/navigation/utils/wrapper.dart
@@ -6,6 +6,7 @@ class Wrapper extends StatelessWidget {
   final List<GetPage>? namedRoutes;
   final String? initialRoute;
   final Transition? defaultTransition;
+  final ThemeData? theme;
 
   const Wrapper({
     Key? key,
@@ -13,6 +14,7 @@ class Wrapper extends StatelessWidget {
     this.namedRoutes,
     this.initialRoute,
     this.defaultTransition,
+    this.theme,
   }) : super(key: key);
 
   @override
@@ -23,6 +25,7 @@ class Wrapper extends StatelessWidget {
       translations: WrapperTranslations(),
       locale: WrapperTranslations.locale,
       getPages: namedRoutes,
+      theme: theme,
       home: Scaffold(
         body: child,
       ),


### PR DESCRIPTION
I changed the plugin to use the consistent background color of the bottom sheet using `BottomSheetThemeData`.

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [X] All existing and new tests are passing.
