### PR TITLE
Update rx_notifier.dart

### DIFF
--- a/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
+++ b/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
@@ -46,7 +46,6 @@ mixin StateMixin<T> on ListNotifier {
     _status = newStatus;
     if (newStatus is SuccessState<T>) {
       _value = newStatus.data!;
-      return;
     }
     refresh();
   }


### PR DESCRIPTION
fix refresh() not called when status equals to SuccessState
