### PR TITLE
Add option to parse animation curve to bottomsheet route

### DIFF
--- a/lib/get_navigation/src/bottomsheet/bottomsheet.dart
+++ b/lib/get_navigation/src/bottomsheet/bottomsheet.dart
@@ -21,6 +21,7 @@ class GetModalBottomSheetRoute<T> extends PopupRoute<T> {
     RouteSettings? settings,
     this.enterBottomSheetDuration = const Duration(milliseconds: 250),
     this.exitBottomSheetDuration = const Duration(milliseconds: 200),
+    this.curve,
   }) : super(settings: settings) {
     RouterReportManager.instance.reportCurrentRoute(this);
   }
@@ -38,6 +39,7 @@ class GetModalBottomSheetRoute<T> extends PopupRoute<T> {
   // final String name;
   final Duration enterBottomSheetDuration;
   final Duration exitBottomSheetDuration;
+  final Curve? curve;
   // remove safearea from top
   final bool removeTop;
 
@@ -61,6 +63,15 @@ class GetModalBottomSheetRoute<T> extends PopupRoute<T> {
     super.dispose();
   }
 
+  @override
+  Animation<double> createAnimation() {
+    if (curve != null) {
+      return CurvedAnimation(
+          curve: curve!, parent: _animationController!.view);
+    }
+    return _animationController!.view;
+  }
+  
   @override
   AnimationController createAnimationController() {
     assert(_animationController == null);

--- a/lib/get_navigation/src/extension_navigation.dart
+++ b/lib/get_navigation/src/extension_navigation.dart
@@ -31,6 +31,7 @@ extension ExtensionBottomSheet on GetInterface {
     RouteSettings? settings,
     Duration? enterBottomSheetDuration,
     Duration? exitBottomSheetDuration,
+    Curve? curve,
   }) {
     return Navigator.of(overlayContext!, rootNavigator: useRootNavigator)
         .push(GetModalBottomSheetRoute<T>(
@@ -56,6 +57,7 @@ extension ExtensionBottomSheet on GetInterface {
           enterBottomSheetDuration ?? const Duration(milliseconds: 250),
       exitBottomSheetDuration:
           exitBottomSheetDuration ?? const Duration(milliseconds: 200),
+      curve: curve,
     ));
   }
 }


### PR DESCRIPTION
This adds the option to pass an animation curve to the bottom sheet in GetModalBottomSheetRoute by overriding the createAnimation() function from Route.

