### PR TITLE
Null safe Get.engine

### DIFF
--- a/lib/get_navigation/src/extension_navigation.dart
+++ b/lib/get_navigation/src/extension_navigation.dart
@@ -1059,7 +1059,7 @@ extension GetNavigationExt on GetInterface {
   /// Your entire application will be rebuilt, and touch events will not
   /// work until the end of rendering.
   Future<void> forceAppUpdate() async {
-    await engine!.performReassemble();
+    await engine.performReassemble();
   }
 
   void appUpdate() => _getxController.update();
@@ -1173,12 +1173,9 @@ extension GetNavigationExt on GetInterface {
     return _theme;
   }
 
-  ///The current [WidgetsBinding]
-  WidgetsBinding? get engine {
-    if (WidgetsBinding.instance == null) {
-      WidgetsFlutterBinding();
-    }
-    return WidgetsBinding.instance;
+  /// The current null safe [WidgetsBinding]
+  WidgetsBinding get engine {
+    return WidgetsFlutterBinding.ensureInitialized();
   }
 
   /// The window to which this binding is bound.

--- a/lib/get_navigation/src/root/get_cupertino_app.dart
+++ b/lib/get_navigation/src/root/get_cupertino_app.dart
@@ -199,7 +199,7 @@ class GetCupertinoApp extends StatelessWidget {
           Get.routeInformationParser = null;
         },
         initState: (i) {
-          Get.engine!.addPostFrameCallback((timeStamp) {
+          Get.engine.addPostFrameCallback((timeStamp) {
             onReady?.call();
           });
           if (locale != null) Get.locale = locale;

--- a/lib/get_navigation/src/root/get_material_app.dart
+++ b/lib/get_navigation/src/root/get_material_app.dart
@@ -215,7 +215,7 @@ class GetMaterialApp extends StatelessWidget {
       initState: (i) {
         // Get.routerDelegate = routerDelegate;
         // Get.routeInformationParser = routeInformationParser;
-        Get.engine!.addPostFrameCallback((timeStamp) {
+        Get.engine.addPostFrameCallback((timeStamp) {
           onReady?.call();
         });
         if (locale != null) Get.locale = locale;


### PR DESCRIPTION
I have made the `Get.engine` getter null safe to facilitate its use. Plus, I've removed the null check operator `!` used within the package that was always used after the getter call.

The updated function looks like this:
```
  /// The current null safe [WidgetsBinding]
  WidgetsBinding get engine {
    return WidgetsFlutterBinding.ensureInitialized();
  }
```

Previously it looked like this:
```
  ///The current [WidgetsBinding]
  WidgetsBinding? get engine {
    if (WidgetsBinding.instance == null) {
      WidgetsFlutterBinding();
    }
    return WidgetsBinding.instance;
  }
```
which was just a non null safe version of the `WidgetsFlutterBinding.ensureInitialized()` function, that's why the new version is just a call to that.

Note that this change will throw warnings on IDEs and during compilation, but it should NOT break code or compilation. 

Let met know if I need anything more on this PR.

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [ ] All existing and new tests are passing.
