### PR TITLE
fix: runMiddleware break if page changed #2194

### DIFF
--- a/lib/get_navigation/src/routes/get_router_delegate.dart
+++ b/lib/get_navigation/src/routes/get_router_delegate.dart
@@ -111,6 +111,16 @@ class GetDelegate extends RouterDelegate<RouteDecoder>
       var redirectRes = await item.redirectDelegate(iterator);
       if (redirectRes == null) return null;
       iterator = redirectRes;
+      // Stop the iteration over the middleware if we changed page
+      // and that redirectRes is not the same as the current config.
+      if (redirectRes != null && config != redirectRes) {
+        break;
+      };
+    }
+    // If the target is not the same as the source, we need
+    // to run the middlewares for the new route.
+    if (iterator != config) {
+      return await runMiddleware(iterator);
     }
     return iterator;
   }


### PR DESCRIPTION
If a middleware using redirectDelegate returned a different route using return RouteDecoder.fromRoute for example, the middlewares executions stack continued and we ended up with middleware being executed on the wrong route.

Fix this by breaking the middlewares loop if the redirection is not the same as the current route and not null.

We must also ensure that we run the middlewares of the new route (if any).
