### PR TITLE
removing ? from declaration

### DIFF
--- a/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
+++ b/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
@@ -167,7 +167,7 @@ abstract class _RxImpl<T> extends GetListenable<T> with RxObjectMixin<T> {
   /// });
   /// print( person );
   /// ```
-  void update(void fn(T? val)) {
+  void update(void fn(T val)) {
     fn(value);
     subject.add(value);
   }


### PR DESCRIPTION
since value is of type T and not T?, value might not hold null at all.

*skipped this for the minor change*
