### PR TITLE
removing the white spaces from email before validating

### DIFF
--- a/lib/get_utils/src/get_utils/get_utils.dart
+++ b/lib/get_utils/src/get_utils/get_utils.dart
@@ -208,10 +208,17 @@ class GetUtils {
   static bool isURL(String s) => hasMatch(s,
       r"^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?))\://)?(www.|[a-zA-Z0-9].)[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,6}(\:[0-9]{1,5})*(/($|[a-zA-Z0-9\.\,\;\?\'\\\+&amp;%\$#\=~_\-]+))*$");
 
-  /// Checks if string is email.
-  static bool isEmail(String s) => hasMatch(s,
-      r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$');
+  /// Removes all the white spaces from the string
+  static String removeAllWhiteSpaces(String s) => s.trimLeft();
 
+  /// Checks if string is email.
+  static bool isEmail(String s) {
+    /// removes all the white spaces from the given email if user or the auto
+    /// correct enterd the empthy spaces
+    final sWithOutWhiteSpces = removeAllWhiteSpaces(s);
+    return hasMatch(sWithOutWhiteSpces,
+        r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$');
+  } 
   /// Checks if string is phone number.
   static bool isPhoneNumber(String s) {
     if (s.length > 16 || s.length < 9) return false;

--- a/lib/get_utils/src/get_utils/get_utils.dart
+++ b/lib/get_utils/src/get_utils/get_utils.dart
@@ -1,4 +1,3 @@
-import '../../../get_connect/http/src/utils/utils.dart';
 import '../../../get_core/get_core.dart';
 
 /// Returns whether a dynamic value PROBABLY
@@ -209,18 +208,9 @@ class GetUtils {
   static bool isURL(String s) => hasMatch(s,
       r"^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?))\://)?(www.|[a-zA-Z0-9].)[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,6}(\:[0-9]{1,5})*(/($|[a-zA-Z0-9\.\,\;\?\'\\\+&amp;%\$#\=~_\-]+))*$");
 
-  /// Removes all the white spaces from back of the string
-  static String trimFromLeft(String s) => s.trimLeft();
-
   /// Checks if string is email.
-  static bool isEmail(String s) {
-    /// If user or the auto complete has enterd the space at the 
-    /// end of the email then the fallowing function will remove it and then 
-    /// validate the *email*
-    final sWithOutWhiteSpacesAtEnd = trimFromLeft(s);
-    return hasMatch(sWithOutWhiteSpacesAtEnd,
-        r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$');
-  }
+  static bool isEmail(String s) => hasMatch(s,
+      r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$');
 
   /// Checks if string is phone number.
   static bool isPhoneNumber(String s) {

--- a/lib/get_utils/src/get_utils/get_utils.dart
+++ b/lib/get_utils/src/get_utils/get_utils.dart
@@ -1,3 +1,4 @@
+import '../../../get_connect/http/src/utils/utils.dart';
 import '../../../get_core/get_core.dart';
 
 /// Returns whether a dynamic value PROBABLY
@@ -208,9 +209,18 @@ class GetUtils {
   static bool isURL(String s) => hasMatch(s,
       r"^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?))\://)?(www.|[a-zA-Z0-9].)[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,6}(\:[0-9]{1,5})*(/($|[a-zA-Z0-9\.\,\;\?\'\\\+&amp;%\$#\=~_\-]+))*$");
 
+  /// Removes all the white spaces from back of the string
+  static String trimFromLeft(String s) => s.trimLeft();
+
   /// Checks if string is email.
-  static bool isEmail(String s) => hasMatch(s,
-      r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$');
+  static bool isEmail(String s) {
+    /// If user or the auto complete has enterd the space at the 
+    /// end of the email then the fallowing function will remove it and then 
+    /// validate the *email*
+    final sWithOutWhiteSpacesAtEnd = trimFromLeft(s);
+    return hasMatch(sWithOutWhiteSpacesAtEnd,
+        r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$');
+  }
 
   /// Checks if string is phone number.
   static bool isPhoneNumber(String s) {


### PR DESCRIPTION
When we use *GetUtil.isEmail()* util, it false if user or the auto correct accidentally entered empty space at the end, middle or at the start.
I created another util to remove empty space from the string and used in the  *GetUtil.isEmail()* util, before validating!

![before](https://user-images.githubusercontent.com/77727680/162381951-55b6d424-5672-4c3d-86b6-79175b61d25b.png)
![after](https://user-images.githubusercontent.com/77727680/162381979-1569e8f3-d639-4b5b-a513-51e085883087.png)


## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
