### PR TITLE
Fixed bug in dependency deletion.

### DIFF
--- a/lib/get_instance/src/get_instance.dart
+++ b/lib/get_instance/src/get_instance.dart
@@ -354,7 +354,7 @@ class GetInstance {
     if (dep == null) return false;
 
     final _InstanceBuilderFactory builder;
-    if (dep.isDirty) {
+    if (dep.lateRemove != null) {
       builder = dep.lateRemove ?? dep;
     } else {
       builder = dep;


### PR DESCRIPTION
Before the Binding creates dependencies for a new route, the dependencies from the old route are marked as "dirty".  However, if the new route adds one of those same dependencies, then the dirty dependency is moved to the 'lateRemove' property and the root dependency is no longer marked 'isDirty'.  This means, when Get.delete() is eventually called on the dependency, the lifecycle 'delete()' is called on the new dependency instead of the old one, and the old dependency ends up being removed from memory (To summarize: The delete() method is called on the wrong controller if both the old and new route have the same controller in their Binding.).

It seems like the delete() lifecycle method should always be called on the same dependency that ends up being removed from memory, which this change fixes.

Every PR must update the corresponding documentation in the `code`, and also the readme in english with the following changes.

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [ ] All existing and new tests are passing.
