### PR TITLE
response interception

### DIFF
--- a/lib/get_connect/http/src/http.dart
+++ b/lib/get_connect/http/src/http.dart
@@ -342,6 +342,19 @@ class GetHttpClient {
       responseInterceptor: _responseInterceptor(responseInterceptor),
     );
   }
+  Future<Response<T>> send<T>(Request<T> request) async {
+    try {
+      var response = await _performRequest<T>(() => Future.value(request));
+      return response;
+    } on Exception catch (e) {
+      if (!errorSafety) {
+        throw GetHttpException(e.toString());
+      }
+      return Future.value(Response<T>(
+        statusText: 'Can not connect to server. Reason: $e',
+      ));
+    }
+  }
 
   Future<Response<T>> patch<T>(
     String url, {

--- a/lib/get_connect/http/src/http/io/http_request_io.dart
+++ b/lib/get_connect/http/src/http/io/http_request_io.dart
@@ -8,6 +8,7 @@ import '../../response/response.dart';
 import '../interface/request_base.dart';
 import '../utils/body_decoder.dart';
 
+
 /// A `dart:io` implementation of `HttpRequestBase`.
 class HttpRequestImpl extends HttpRequestBase {
   io.HttpClient? _httpClient;
@@ -57,6 +58,10 @@ class HttpRequestImpl extends HttpRequestBase {
       });
 
       final bodyBytes = (response);
+      
+      final interceptionResponse = await request.responseInterceptor?.call(request, T, response);
+      if(interceptionResponse != null) return interceptionResponse;
+        
       final stringBody = await bodyBytesToString(bodyBytes, headers);
 
       final body = bodyDecoded<T>(

--- a/lib/get_connect/http/src/request/request.dart
+++ b/lib/get_connect/http/src/request/request.dart
@@ -13,6 +13,8 @@ class Request<T> {
   final Uri url;
 
   final Decoder<T>? decoder;
+  
+  final ResponseInterceptor<T>? responseInterceptor;
 
   /// The Http Method from this [Request]
   /// ex: `GET`,`POST`,`PUT`,`DELETE`
@@ -44,6 +46,7 @@ class Request<T> {
     required this.files,
     required this.persistentConnection,
     required this.decoder,
+    this.responseInterceptor,
   });
 
   factory Request({
@@ -57,6 +60,7 @@ class Request<T> {
     FormData? files,
     bool persistentConnection = true,
     Decoder<T>? decoder,
+    ResponseInterceptor<T>? responseInterceptor,
   }) {
     if (followRedirects) {
       assert(maxRedirects > 0);
@@ -72,6 +76,7 @@ class Request<T> {
       files: files,
       persistentConnection: persistentConnection,
       decoder: decoder,
+      responseInterceptor: responseInterceptor
     );
   }
 

--- a/lib/get_connect/http/src/request/request.dart
+++ b/lib/get_connect/http/src/request/request.dart
@@ -92,6 +92,7 @@ class Request<T> {
     bool? persistentConnection,
     Decoder<T>? decoder,
     bool appendHeader = true,
+    ResponseInterceptor<T>? responseInterceptor,
   }) {
     // If appendHeader is set to true, we will merge origin headers with that
     if (appendHeader && headers != null) {
@@ -109,6 +110,7 @@ class Request<T> {
       files: files ?? this.files,
       persistentConnection: persistentConnection ?? this.persistentConnection,
       decoder: decoder ?? this.decoder,
+      responseInterceptor: responseInterceptor ?? this.responseInterceptor
     );
   }
 }

--- a/lib/get_state_manager/src/simple/list_notifier.dart
+++ b/lib/get_state_manager/src/simple/list_notifier.dart
@@ -178,7 +178,7 @@ class Notifier {
     if (data.disposers.isEmpty && data.throwException) {
       throw ObxError();
     }
-    _notifyData = data;
+    _notifyData = null;
     return result;
   }
 }


### PR DESCRIPTION
gives the possibility to intercept the core response before the final response is created, which is based on the default decoding process. This solves https://github.com/jonataslaw/getx/issues/2030 

Every PR must update the corresponding documentation in the `code`, and also the readme in english with the following changes.

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt. **=> Since I couldn't find any tests with respect to get_connect, I skipped this**
- [ ] All existing and new tests are passing. **=> There are failing tests which are unrelated to my added code. I suppose they've already been failing before.**
