### PR TITLE
refactor(binding): use the new binding everywhere

### DIFF
--- a/documentation/ar_EG/state_management.md
+++ b/documentation/ar_EG/state_management.md
@@ -507,7 +507,7 @@ GetBuilder<Controller>(
 
 * You have already learned how to manage states with Get.
 
-* Note: You may want a larger organization, and not use the init property. For that, you can create a class and extends Bindings class, and within it mention the controllers that will be created within that route. Controllers will not be created at that time, on the contrary, this is just a statement, so that the first time you use a Controller, Get will know where to look. Get will remain lazyLoad, and will continue to dispose Controllers when they are no longer needed. See the pub.dev example to see how it works.
+* Note: You may want a larger organization, and not use the init property. For that, you can create a class and extends Binding class, and within it mention the controllers that will be created within that route. Controllers will not be created at that time, on the contrary, this is just a statement, so that the first time you use a Controller, Get will know where to look. Get will remain lazyLoad, and will continue to dispose Controllers when they are no longer needed. See the pub.dev example to see how it works.
 
 If you navigate many routes and need data that was in your previously used controller, you just need to use GetBuilder Again (with no init):
 

--- a/documentation/en_US/state_management.md
+++ b/documentation/en_US/state_management.md
@@ -507,7 +507,7 @@ GetBuilder<Controller>(
 
 * You have already learned how to manage states with Get.
 
-* Note: You may want a larger organization, and not use the init property. For that, you can create a class and extends Bindings class, and within it mention the controllers that will be created within that route. Controllers will not be created at that time, on the contrary, this is just a statement, so that the first time you use a Controller, Get will know where to look. Get will remain lazyLoad, and will continue to dispose Controllers when they are no longer needed. See the pub.dev example to see how it works.
+* Note: You may want a larger organization, and not use the init property. For that, you can create a class and extends Binding class, and within it mention the controllers that will be created within that route. Controllers will not be created at that time, on the contrary, this is just a statement, so that the first time you use a Controller, Get will know where to look. Get will remain lazyLoad, and will continue to dispose Controllers when they are no longer needed. See the pub.dev example to see how it works.
 
 If you navigate many routes and need data that was in your previously used controller, you just need to use GetBuilder Again (with no init):
 

--- a/example/example.md
+++ b/example/example.md
@@ -200,12 +200,14 @@ Bindings is the first step towards having a scalable application, you can visual
 To create a Binding, simply create a class and implement Bindings
 
 ```dart
-class SampleBind extends Bindings {
+class SampleBind extends Binding {
   @override
-  void dependencies() {
-    Get.lazyPut<Controller>(() => Controller());
-    Get.lazyPut<Controller2>(() => Controller2());
-    Get.lazyPut<Controller3>(() => Controller3());
+  List<Bind> dependencies() {
+    return [
+      Bind.lazyPut<Controller>(() => Controller()),
+      Bind.lazyPut<Controller2>(() => Controller2()),
+      Bind.lazyPut<Controller3>(() => Controller3()),
+    ];
   }
 }
 ```
@@ -487,7 +489,7 @@ class Third extends GetView<ControllerX> {
   }
 }
 
-class SampleBind extends Bindings {
+class SampleBind extends Binding {
   @override
   void dependencies() {
     Get.lazyPut<ControllerX>(() => ControllerX());

--- a/example/lib/pages/home/bindings/home_binding.dart
+++ b/example/lib/pages/home/bindings/home_binding.dart
@@ -5,11 +5,13 @@ import '../data/home_repository.dart';
 import '../domain/adapters/repository_adapter.dart';
 import '../presentation/controllers/home_controller.dart';
 
-class HomeBinding extends Bindings {
+class HomeBinding extends Binding {
   @override
-  void dependencies() {
-    Get.lazyPut<IHomeProvider>(() => HomeProvider());
-    Get.lazyPut<IHomeRepository>(() => HomeRepository(provider: Get.find()));
-    Get.lazyPut(() => HomeController(homeRepository: Get.find()));
+  List<Bind> dependencies() {
+    return [
+      Bind.lazyPut<IHomeProvider>(() => HomeProvider()),
+      Bind.lazyPut<IHomeRepository>(() => HomeRepository(provider: Get.find())),
+      Bind.lazyPut(() => HomeController(homeRepository: Get.find())),
+    ];
   }
 }

--- a/example_nav2/lib/app/modules/products/bindings/products_binding.dart
+++ b/example_nav2/lib/app/modules/products/bindings/products_binding.dart
@@ -2,11 +2,13 @@ import 'package:get/get.dart';
 
 import '../controllers/products_controller.dart';
 
-class ProductsBinding extends Bindings {
+class ProductsBinding extends Binding {
   @override
-  void dependencies() {
-    Get.lazyPut<ProductsController>(
-      () => ProductsController(),
-    );
+  List<Bind> dependencies() {
+    return [
+      Bind.lazyPut<ProductsController>(
+        () => ProductsController(),
+      )
+    ];
   }
 }


### PR DESCRIPTION
## Description

`extends Bindings` is deprecated now, so change to the new way everywhere

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
