### PR TITLE
Fixed generic type and equality assert

### DIFF
--- a/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
+++ b/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
@@ -247,11 +247,11 @@ typedef NotifierBuilder<T> = Widget Function(T state);
 
 abstract class GetStatus<T> with Equality {
   const GetStatus();
-  factory GetStatus.loading() => LoadingStatus();
-  factory GetStatus.error(String message) => ErrorStatus(message);
-  factory GetStatus.empty() => EmptyStatus();
-  factory GetStatus.success(T data) => SuccessStatus(data);
-  factory GetStatus.custom() => CustomStatus();
+  factory GetStatus.loading() => LoadingStatus<T>();
+  factory GetStatus.error(String message) => ErrorStatus<T, String>(message);
+  factory GetStatus.empty() => EmptyStatus<T>();
+  factory GetStatus.success(T data) => SuccessStatus<T>(data);
+  factory GetStatus.custom() => CustomStatus<T>();
 }
 
 class CustomStatus<T> extends GetStatus<T> {

--- a/lib/get_utils/src/equality/equality.dart
+++ b/lib/get_utils/src/equality/equality.dart
@@ -8,7 +8,8 @@ mixin Equality {
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
-        const DeepCollectionEquality().equals(props, other.props);
+        runtimeType == other.runtimeType &&
+            const DeepCollectionEquality().equals(props, other.props);
   }
 
   @override


### PR DESCRIPTION
1 - The generic parameters were not properly passed to the factories
2 - The equality was wrong when same prop but different class types

For example:
```dart
EmptyStatus()==LoadingStatus() // return true
```
