### PR TITLE
capitalizeAllWordsFirstLetter() method to capitalize only first letter in String words

### DIFF
--- a/lib/get_utils/src/extensions/string_extensions.dart
+++ b/lib/get_utils/src/extensions/string_extensions.dart
@@ -124,5 +124,8 @@ extension GetStringUtils on String {
     final path = startsWith('/') ? this : '/$this';
     return GetUtils.createPath(path, segments);
   }
-  String capitalizeAllWordsFirstLetter() =>  GetUtils.capitalizeAllWordsFirstLetter(this);
+
+  /// capitalize only first letter in String words to upper case
+  String capitalizeAllWordsFirstLetter() =>
+      GetUtils.capitalizeAllWordsFirstLetter(this);
 }

--- a/lib/get_utils/src/extensions/string_extensions.dart
+++ b/lib/get_utils/src/extensions/string_extensions.dart
@@ -124,4 +124,5 @@ extension GetStringUtils on String {
     final path = startsWith('/') ? this : '/$this';
     return GetUtils.createPath(path, segments);
   }
+  String capitalizeAllWordsFirstLetter() =>  GetUtils.capitalizeAllWordsFirstLetter(this);
 }

--- a/lib/get_utils/src/get_utils/get_utils.dart
+++ b/lib/get_utils/src/get_utils/get_utils.dart
@@ -595,6 +595,45 @@ class GetUtils {
     return numericOnlyStr;
   }
 
+  /// capitalize the first letter of each word in a string
+  /// Example: your name => Your Name
+  /// Example 2 : this is an example text=> This Is An Example Text
+  // "emm, lemme        think !",
+  static String capitalizeAllWordsFirstLetter(String s) {
+    String lowerCasedString = s.toLowerCase();
+    String stringWithoutExtraSpaces = lowerCasedString.trim();
+
+    if (stringWithoutExtraSpaces.isEmpty) {
+      return "";
+    }
+    if (stringWithoutExtraSpaces.length == 1) {
+      return stringWithoutExtraSpaces.toUpperCase();
+    }
+
+    List<String> stringWordsList = stringWithoutExtraSpaces.split(" ");
+    List<String> capitalizedWordsFirstLetter = stringWordsList
+        .map(
+          (word) {
+            if (word.trim().isEmpty) return "";
+            return word.trim();
+          },
+        )
+        .where(
+          (word) => word != "",
+        )
+        .map(
+          (word) {
+            if (word.startsWith(RegExp(r'[\n\t\r]'))) {
+              return word;
+            }
+            return word[0].toUpperCase() + word.substring(1).toLowerCase();
+          },
+        )
+        .toList();
+    String finalResult = capitalizedWordsFirstLetter.join(" ");
+    return finalResult;
+  }
+
   static bool hasMatch(String? value, String pattern) {
     return (value == null) ? false : RegExp(pattern).hasMatch(value);
   }

--- a/lib/get_utils/src/get_utils/get_utils.dart
+++ b/lib/get_utils/src/get_utils/get_utils.dart
@@ -595,10 +595,9 @@ class GetUtils {
     return numericOnlyStr;
   }
 
-  /// capitalize the first letter of each word in a string
-  /// Example: your name => Your Name
-  /// Example 2 : this is an example text=> This Is An Example Text
-  // "emm, lemme        think !",
+  /// Capitalize only the first letter of each word in a string
+  /// Example: getx will make it easy  => Getx Will Make It Easy
+  /// Example 2 : this is an example text => This Is An Example Text
   static String capitalizeAllWordsFirstLetter(String s) {
     String lowerCasedString = s.toLowerCase();
     String stringWithoutExtraSpaces = lowerCasedString.trim();

--- a/test/utils/extensions/string_extensions_test.dart
+++ b/test/utils/extensions/string_extensions_test.dart
@@ -16,6 +16,42 @@ void main() {
       expect(text.isNum, false);
     });
 
+    test('var.capitalizeAllWordsFirstLetter()', () {
+      final List<String> sentences = [
+        "getx",
+        "this is an example sentence",
+        "this is an example sentence with a number 5",
+        "this is an example sentence with a number 5 and a special character #",
+        "this is an example sentence with a number 5 and a special character # and b letter C",
+        "    emm, lemme        think !",
+        "Bro, $letters is a good word",
+        "THIS IS A SENTENCE WITH ALL CAPITAL LETTERS",
+        ""
+      ];
+      expect(text.capitalizeAllWordsFirstLetter(), "Oi");
+      expect(digit.capitalizeAllWordsFirstLetter(), "5");
+      expect(specialCaracters.capitalizeAllWordsFirstLetter(), "#\$!%@");
+      expect(alphaNumeric.capitalizeAllWordsFirstLetter(), "123asd");
+      expect(numbers.capitalizeAllWordsFirstLetter(), "123");
+      expect(letters.capitalizeAllWordsFirstLetter(), "Foo");
+      expect(sentences[0].capitalizeAllWordsFirstLetter(), "Getx");
+      expect(sentences[1].capitalizeAllWordsFirstLetter(),
+          "This Is An Example Sentence");
+      expect(sentences[2].capitalizeAllWordsFirstLetter(),
+          "This Is An Example Sentence With A Number 5");
+      expect(sentences[3].capitalizeAllWordsFirstLetter(),
+          "This Is An Example Sentence With A Number 5 And A Special Character #");
+      expect(sentences[4].capitalizeAllWordsFirstLetter(),
+          "This Is An Example Sentence With A Number 5 And A Special Character # And B Letter C");
+      expect(
+          sentences[5].capitalizeAllWordsFirstLetter(), "Emm, Lemme Think !");
+      expect(sentences[6].capitalizeAllWordsFirstLetter(),
+          "Bro, Foo Is A Good Word");
+      expect(sentences[7].capitalizeAllWordsFirstLetter(),
+          "This Is A Sentence With All Capital Letters");
+      expect(sentences[8].capitalizeAllWordsFirstLetter(), "");
+    });
+
     test('var.isNumericOnly', () {
       expect(numbers.isNumericOnly, true);
       expect(letters.isNumericOnly, false);


### PR DESCRIPTION
turn the first letter only of words in a String to uppercase(), tested it with examples

*capitalizeAllWordsFirstLetter() will turn the first letter of words to upper case and the rest to lower case, useful in cases of writing titles of screens, articles titles, buttons and ad banners...*

Every PR must update the corresponding documentation in the `code`, and also the readme in English with the following changes.

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
