### PR TITLE
Fixes Theme not changing on System Dark Mode

### DIFF
--- a/lib/get_navigation/src/root/root_controller.dart
+++ b/lib/get_navigation/src/root/root_controller.dart
@@ -210,14 +210,12 @@ class GetMaterialController extends FullLifeCycleController {
   }
 
   void setTheme(ThemeData value) {
-    if (darkTheme == null) {
+    if (value.brightness == Brightness.light) {
+      themeMode = ThemeMode.light;
       theme = value;
     } else {
-      if (value.brightness == Brightness.light) {
-        theme = value;
-      } else {
-        darkTheme = value;
-      }
+      themeMode = ThemeMode.dark;
+      darkTheme = value;
     }
     update();
   }


### PR DESCRIPTION
**This PR addresses the issue: #1411.**
As it stands, `Get.changeTheme()` doesnt seem to work when the system theme is set to **Dark Mode**. This potentially fixes that issue without caring for current themeMode or the system themeMode.

However there is a fix around this issue:
Setting **themeMode** to light: 
```dart
return GetMaterialApp(
      home: Page(),
      themeMode: ThemeMode.light,
    );
``` 

## Pre-launch Checklist

- [] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [] All existing and new tests are passing.
