### PR TITLE
Fixed minor typo in GetConnect document

### DIFF
--- a/README-ar.md
+++ b/README-ar.md
@@ -543,7 +543,6 @@ class HomeProvider extends GetConnect {
     //HttpStatus.unauthorized
     httpClient.maxAuthRetries = 3;
   }
-  }
 
   @override
   Future<Response<CasesModel>> getCases(String path) => get(path);

--- a/README-vi.md
+++ b/README-vi.md
@@ -498,7 +498,6 @@ class HomeProvider extends GetConnect {
     //HttpStatus.unauthorized
     httpClient.maxAuthRetries = 3;
   }
-  }
 
   @override
   Future<Response<CasesModel>> getCases(String path) => get(path);

--- a/README.md
+++ b/README.md
@@ -517,7 +517,6 @@ class HomeProvider extends GetConnect {
     //HttpStatus.unauthorized
     httpClient.maxAuthRetries = 3;
   }
-  }
 
   @override
   Future<Response<CasesModel>> getCases(String path) => get(path);

--- a/README.ur-PK.md
+++ b/README.ur-PK.md
@@ -440,7 +440,6 @@ class HomeProvider extends GetConnect {
     //HttpStatus.unauthorized
     httpClient.maxAuthRetries = 3;
   }
-  }
 
   @override
   Future<Response<CasesModel>> getCases(String path) => get(path);

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -476,7 +476,6 @@ class HomeProvider extends GetConnect {
     //HttpStatus.unauthorized
     httpClient.maxAuthRetries = 3;
   }
-  }
 
   @override
   Future<Response<CasesModel>> getCases(String path) => get(path);


### PR DESCRIPTION
Fixed a minor typo in GetConnect documentation under `Custom configuration` section

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
