### PR TITLE
Support TLDs of up to 7 characters

### DIFF
--- a/lib/get_utils/src/get_utils/get_utils.dart
+++ b/lib/get_utils/src/get_utils/get_utils.dart
@@ -206,7 +206,7 @@ class GetUtils {
 
   /// Checks if string is URL.
   static bool isURL(String s) => hasMatch(s,
-      r"^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?))\://)?(www.|[a-zA-Z0-9].)[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,6}(\:[0-9]{1,5})*(/($|[a-zA-Z0-9\.\,\;\?\'\\\+&amp;%\$#\=~_\-]+))*$");
+      r"^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?))\://)?(www.|[a-zA-Z0-9].)[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,7}(\:[0-9]{1,5})*(/($|[a-zA-Z0-9\.\,\;\?\'\\\+&amp;%\$#\=~_\-]+))*$");
 
   /// Checks if string is email.
   static bool isEmail(String s) => hasMatch(s,

--- a/test/utils/extensions/string_extensions_test.dart
+++ b/test/utils/extensions/string_extensions_test.dart
@@ -213,6 +213,7 @@ void main() {
         'http://appliance.example.com/bee/badge',
         'http://www.example.org/berry.aspx',
         'http://example.org/',
+        'http://birds.example/',
       ];
 
       for (final url in urls) {


### PR DESCRIPTION
`isURL` only supports TLDs up to 6 characters long. However, there are several common TLDs with 7 or more letters: `.example`, `.systems`, etc.

I would be open to increasing this number if desired, because according to RFC 1034, the TLD could be as long as 63 characters.

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.