### PR TITLE
Changed the 'dialogue made in 3 lines' part.

### DIFF
--- a/lib/get_navigation/src/extension_navigation.dart
+++ b/lib/get_navigation/src/extension_navigation.dart
@@ -164,7 +164,7 @@ extension ExtensionDialog on GetInterface {
     Color? backgroundColor,
     bool barrierDismissible = true,
     Color? buttonColor,
-    String middleText = "Dialog made in 3 lines of code",
+    String middleText = "\n",
     TextStyle? middleTextStyle,
     double radius = 20.0,
     //   ThemeData themeData,


### PR DESCRIPTION
The dialogue box, as coded in extension_navigation.dart shows an unprofessional text, "Dialogue made in 3 lines code.", which looks poor in production and to alter the middletext manually using sizedbox shrink is pointless.

Hence, I changed it to, "\n" which just adds an empty line instead of the "Dialogue made in 3 lines" thing. 
