### PR TITLE
update rxlist overrides

### DIFF
--- a/lib/get_rx/src/rx_types/rx_iterables/rx_list.dart
+++ b/lib/get_rx/src/rx_types/rx_iterables/rx_list.dart
@@ -70,6 +70,13 @@ class RxList<E> extends GetListenable<List<E>>
   }
 
   @override
+  bool remove(Object? element) {
+    final removed = value.remove(element);
+    refresh();
+    return removed;
+  }
+
+  @override
   void removeWhere(bool Function(E element) test) {
     value.removeWhere(test);
     refresh();
@@ -105,6 +112,12 @@ class RxList<E> extends GetListenable<List<E>>
 
   @override
   Iterable<E> get reversed => value.reversed;
+
+  @override
+  set value(List<E> val) {
+    super.value = val;
+    refresh();
+  }
 
   @override
   Iterable<E> where(bool Function(E) test) {

--- a/lib/get_rx/src/rx_types/rx_iterables/rx_list.dart
+++ b/lib/get_rx/src/rx_types/rx_iterables/rx_list.dart
@@ -115,7 +115,7 @@ class RxList<E> extends GetListenable<List<E>>
 
   @override
   set value(List<E> val) {
-    super.value = val;
+    value = val;
     refresh();
   }
 

--- a/test/rx/rx_workers_test.dart
+++ b/test/rx/rx_workers_test.dart
@@ -199,6 +199,11 @@ void main() {
     expect(count, 1);
 
     count = 0;
+    list.remove(2);
+    await Future.delayed(Duration.zero);
+    expect(count, 1);
+
+    count = 0;
     list.removeWhere((element) => element == 2);
     await Future.delayed(Duration.zero);
     expect(count, 1);


### PR DESCRIPTION
Observed that some methods on list (remove, value setter) are not overriden by `RxList`, which prevents downstream re-rendering. Let me know how you feel about this / if there is any additional testing or documentation you'd like added.

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [ ] All existing and new tests are passing.
