### PR TITLE
fix: RxList Constructor params use const [] error

### DIFF
--- a/lib/get_rx/src/rx_types/rx_iterables/rx_list.dart
+++ b/lib/get_rx/src/rx_types/rx_iterables/rx_list.dart
@@ -3,7 +3,7 @@ part of rx_types;
 /// Create a list similar to `List<T>`
 class RxList<E> extends GetListenable<List<E>>
     with ListMixin<E>, RxObjectMixin<List<E>> {
-  RxList([List<E> initial = const []]) : super(initial);
+  RxList([List<E>? initial]) : super(initial??<E>[]);
 
   factory RxList.filled(int length, E fill, {bool growable = false}) {
     return RxList(List.filled(length, fill, growable: growable));


### PR DESCRIPTION
### before test:

```dart
void main() {
  test('test', () {
    final a = ATest<int>();
    a.list.add(1);

    expect(1, 1);
  });
}

class Test<T> {
  Test( this.list);

  final List<T> list;
}

class ATest<E> extends Test<E> {
  ATest([List<E> initial  = const []]):super(initial);
}
```
### result:
```
dart:_internal                  UnmodifiableListMixin.add
test\test.dart 6:12  main.<fn>

type 'int' is not a subtype of type 'Never' of 'value
```

so i made it optional

