### PR TITLE
Theme pageTransition

### DIFF
--- a/lib/get_navigation/src/routes/get_transition_mixin.dart
+++ b/lib/get_navigation/src/routes/get_transition_mixin.dart
@@ -723,7 +723,10 @@ Cannot read the previousTitle for a route that has not yet been installed''',
                 route.alignment, animation, secondaryAnimation, child);
           }
 
-          return PageTransitionsTheme().buildTransitions(
+          PageTransitionsTheme pageTransitionsTheme =
+              Theme.of(context).pageTransitionsTheme;
+
+          return pageTransitionsTheme.buildTransitions(
               route,
               context,
               iosAnimation,


### PR DESCRIPTION
Currently, GetX does not use theme pagaTransition, default transition is not taken from theme. It is somehow hard to customize pageTranstion though CustomTransition. That’s why I changed default page transtion.
It is easy to set custom transition through ThemeData.
