### PR TITLE
Fix Get.rawRoute is null when using Get.offAllNamed

### DIFF
--- a/lib/get_navigation/src/routes/observers/route_observer.dart
+++ b/lib/get_navigation/src/routes/observers/route_observer.dart
@@ -131,7 +131,6 @@ class GetObserver extends NavigatorObserver {
     Get.log("REMOVING ROUTE $routeName");
 
     _routeSend?.update((value) {
-      value.route = previousRoute;
       value.isBack = false;
       value.removed = routeName ?? '';
       value.previous = routeName ?? '';

--- a/test/navigation/get_main_test.dart
+++ b/test/navigation/get_main_test.dart
@@ -60,6 +60,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(SecondScreen), findsOneWidget);
+    expect(Get.rawRoute?.settings.name, '/SecondScreen');
   });
 
   testWidgets("Get.off removes current route", (tester) async {
@@ -72,6 +73,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(FirstScreen), findsNothing);
+    expect(Get.rawRoute?.settings.name, '/SecondScreen');
   });
 
   testWidgets("Get.offNamed navigates to provided named route", (tester) async {
@@ -91,6 +93,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(SecondScreen), findsOneWidget);
+    expect(Get.rawRoute?.settings.name, '/second');
   });
 
   testWidgets("Get.offNamed removes current route", (tester) async {
@@ -112,6 +115,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(FirstScreen), findsNothing);
+    expect(Get.rawRoute?.settings.name, '/second');
   });
 
   testWidgets("Get.offNamed removes only current route", (tester) async {
@@ -134,6 +138,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(FirstScreen), findsOneWidget);
+    expect(Get.rawRoute?.settings.name, '/first');
     await tester.pumpAndSettle();
   });
 
@@ -146,6 +151,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(SecondScreen), findsOneWidget);
+    expect(Get.rawRoute?.settings.name, '/SecondScreen');
   });
 
   testWidgets("Get.offAll removes all previous routes", (tester) async {
@@ -166,6 +172,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(FirstScreen), findsNothing);
+    expect(Get.rawRoute?.settings.name, '/ThirdScreen');
   });
 
   testWidgets("Get.offAllNamed navigates to provided named route",
@@ -186,6 +193,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(SecondScreen), findsOneWidget);
+    expect(Get.rawRoute?.settings.name, '/second');
   });
 
   testWidgets("Get.offAllNamed removes all previous routes", (tester) async {
@@ -214,6 +222,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(FirstScreen), findsNothing);
+    expect(Get.rawRoute?.settings.name, '/third');
   });
 
   testWidgets("Get.offAndToNamed navigates to provided route", (tester) async {
@@ -231,6 +240,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(SecondScreen), findsOneWidget);
+    expect(Get.rawRoute?.settings.name, '/second');
   });
 
   testWidgets("Get.offAndToNamed removes previous route", (tester) async {
@@ -251,6 +261,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(FirstScreen), findsNothing);
+    expect(Get.rawRoute?.settings.name, '/second');
   });
 
   testWidgets("Get.offUntil navigates to provided route", (tester) async {
@@ -265,6 +276,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(ThirdScreen), findsOneWidget);
+    expect(Get.rawRoute?.settings.name, '/ThirdScreen');
   });
 
   testWidgets(
@@ -283,6 +295,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(SecondScreen), findsNothing);
+    expect(Get.rawRoute?.settings.name, '/FirstScreen');
   });
 
   testWidgets(
@@ -301,6 +314,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(FirstScreen), findsOneWidget);
+    expect(Get.rawRoute?.settings.name, '/FirstScreen');
   });
 
   testWidgets("Get.offNamedUntil navigates to provided route", (tester) async {
@@ -318,6 +332,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(SecondScreen), findsOneWidget);
+    expect(Get.rawRoute?.settings.name, '/second');
   });
 
   testWidgets(
@@ -339,6 +354,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(SecondScreen), findsNothing);
+    expect(Get.rawRoute?.settings.name, '/third');
   });
 
   testWidgets(
@@ -362,6 +378,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(FirstScreen), findsOneWidget);
+    expect(Get.rawRoute?.settings.name, '/first');
   });
 
   testWidgets("Get.back navigates back", (tester) async {


### PR DESCRIPTION
This PR fixes issue #1237 

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
