### PR TITLE
fix leakage in routerReportManager

### DIFF
--- a/lib/get_navigation/src/router_report.dart
+++ b/lib/get_navigation/src/router_report.dart
@@ -119,6 +119,10 @@ class RouterReportManager<T> {
       }
     }
 
+    if (_routesKey[routeName]?.isEmpty ?? false) {
+      _routesKey.remove(routeName);
+    }
+
     keysToRemove.clear();
   }
 }


### PR DESCRIPTION
 the key  in _ Routeskey  may remove when value is empty #1854 and  #2480
