### PR TITLE
fixing the example markdown to use the name Home instead of HomeView …

### DIFF
--- a/example/example.md
+++ b/example/example.md
@@ -240,7 +240,7 @@ void main() {
   runApp(GetMaterialApp(
     initialRoute: '/home',
     getPages: [
-      GetPage(name: '/home', page: () => HomeView(), binding: HomeBinding()),
+      GetPage(name: '/home', page: () => Home(), binding: HomeBinding()),
     ],
   ));
 }


### PR DESCRIPTION

*Changing the example.md file also shown on the pub dev, In the GetView example for the GetPage of the HomeView it uses HomeView instead of Home*

Every PR must update the corresponding documentation in the `code`, and also the readme in english with the following changes.

## Pre-launch Checklist

Dont this it is relevant

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [ ] All existing and new tests are passing.
