### PR TITLE
Added New method Get.findOrNull ()

### DIFF
--- a/lib/get_instance/src/extension_instance.dart
+++ b/lib/get_instance/src/extension_instance.dart
@@ -298,6 +298,17 @@ extension Inst on GetInterface {
     }
   }
 
+  
+  /// The findOrNull method will return the instance if it is registered;
+  /// otherwise, it will return null.
+  S? findOrNull<S>({String? tag}) {
+    if (isRegistered<S>(tag: tag)) {
+      return find<S>(tag: tag);
+    }
+    return null;
+  }
+
+
   /// Replace a parent instance of a class in dependency management
   /// with a [child] instance
   /// - [tag] optional, if you use a [tag] to register the Instance.

--- a/test/instance/get_instance_test.dart
+++ b/test/instance/get_instance_test.dart
@@ -55,12 +55,9 @@ void main() {
     final instance = Get.put<Controller>(Controller(), tag: 'one');
     final instance2 = Get.put<Controller>(Controller(), tag: 'two');
     expect(instance == instance2, false);
-    expect(Get.find<Controller>(tag: 'one') == Get.find<Controller>(tag: 'two'),
-        false);
-    expect(Get.find<Controller>(tag: 'one') == Get.find<Controller>(tag: 'one'),
-        true);
-    expect(Get.find<Controller>(tag: 'two') == Get.find<Controller>(tag: 'two'),
-        true);
+    expect(Get.find<Controller>(tag: 'one') == Get.find<Controller>(tag: 'two'), false);
+    expect(Get.find<Controller>(tag: 'one') == Get.find<Controller>(tag: 'one'), true);
+    expect(Get.find<Controller>(tag: 'two') == Get.find<Controller>(tag: 'two'), true);
     Get.reset();
   });
 
@@ -68,12 +65,9 @@ void main() {
     Get.lazyPut<Controller>(() => Controller(), tag: 'one');
     Get.lazyPut<Controller>(() => Controller(), tag: 'two');
 
-    expect(Get.find<Controller>(tag: 'one') == Get.find<Controller>(tag: 'two'),
-        false);
-    expect(Get.find<Controller>(tag: 'one') == Get.find<Controller>(tag: 'one'),
-        true);
-    expect(Get.find<Controller>(tag: 'two') == Get.find<Controller>(tag: 'two'),
-        true);
+    expect(Get.find<Controller>(tag: 'one') == Get.find<Controller>(tag: 'two'), false);
+    expect(Get.find<Controller>(tag: 'one') == Get.find<Controller>(tag: 'one'), true);
+    expect(Get.find<Controller>(tag: 'two') == Get.find<Controller>(tag: 'two'), true);
     Get.reset();
   });
 
@@ -101,8 +95,7 @@ void main() {
 
     expect(Get.find<Controller>().count, 1);
     Get.delete<Controller>();
-    expect(
-        () => Get.find<Controller>(), throwsA(const m.TypeMatcher<String>()));
+    expect(() => Get.find<Controller>(), throwsA(const m.TypeMatcher<String>()));
     Get.reset();
   });
 
@@ -162,12 +155,10 @@ void main() {
     test('Get.delete test with disposable controller', () async {
       // Get.put(DisposableController());
       expect(Get.delete<DisposableController>(), true);
-      expect(() => Get.find<DisposableController>(),
-          throwsA(const m.TypeMatcher<String>()));
+      expect(() => Get.find<DisposableController>(), throwsA(const m.TypeMatcher<String>()));
     });
 
-    test('Get.put test after delete with disposable controller and init check',
-        () async {
+    test('Get.put test after delete with disposable controller and init check', () async {
       final instance = Get.put<DisposableController>(DisposableController());
       expect(instance, Get.find<DisposableController>());
       expect(instance.initialized, true);
@@ -251,6 +242,20 @@ void main() {
       expect((Get.find<DisposableController>() as Controller).count, 1);
       Get.delete<DisposableController>();
       expect((Get.find<DisposableController>() as Controller).count, 0);
+    });
+  });
+
+  group('Get.findOrNull test', () {
+    tearDown(Get.reset);
+    test('checking results', () async {
+      Get.put<int>(1);
+      int? result = Get.findOrNull<int>();
+      expect(result, 1);
+      
+      Get.delete<int>();
+      result = Get.findOrNull<int>();
+      expect(result, null);
+
     });
   });
 }


### PR DESCRIPTION
Implemented findOrNull method

This pull request adds a new method called findOrNull to GetX. The method is similar to the existing find method but instead of throwing an error when the specified dependency is not found, it returns null.

This methods aims to avoid writing more boilerplate code like this

```
if (Get.isRegistered<ControllerX>()){
  Get.find<ControllerX>().refresh();
}
```
To this

```
Get.findOrNull<ControllerX>()?.refresh();
```

## Pre-launch Checklist

- [ Done] I updated/added relevant documentation (doc comments with `///`).
- [ Done] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [Partial] All existing and new tests are passing. There is one test in example failing but it was also failing before making changes
