### PR TITLE
fix: respect query and required parameters

### DIFF
--- a/lib/get_navigation/src/routes/get_router_delegate.dart
+++ b/lib/get_navigation/src/routes/get_router_delegate.dart
@@ -700,9 +700,7 @@ class GetDelegate extends RouterDelegate<RouteDecoder>
       RouteDecoder decoder, PageSettings arguments) {
     final parameters =
         arguments.params.isEmpty ? arguments.query : arguments.params;
-    if (arguments.params.isEmpty) {
-      arguments.params.addAll(arguments.query);
-    }
+    arguments.params.addAll(arguments.query);
     if (decoder.parameters.isEmpty) {
       decoder.parameters.addAll(parameters);
     }

--- a/test/navigation/parse_route_test.dart
+++ b/test/navigation/parse_route_test.dart
@@ -160,6 +160,14 @@ void main() {
 
       expect(Get.parameters['id'], '1234');
       expect(Get.parameters['name'], 'ana');
+
+      Get.toNamed('/last/1234/ana/profile?job=dev');
+
+      await tester.pumpAndSettle();
+
+      expect(Get.parameters['id'], '1234');
+      expect(Get.parameters['name'], 'ana');
+      expect(Get.parameters['job'], 'dev');
     },
   );
 


### PR DESCRIPTION
The router doesn't include optional query-string parameters when required parameters are present.

For example, `/route/:id` and `/route?id=1` are respected, but `/route/:id/profile?title=dev` only parses `:id`. This PR provides `:id` and `title` to `Get.parameters`

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
