### PR TITLE
refactor: migrate MediaQuery `context_extensions` to InheritedModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,19 +680,19 @@ context.height
 context.heightTransformer()
 context.widthTransformer()
 
-/// Similar to MediaQuery.of(context).size
+/// Similar to MediaQuery.sizeOf(context);
 context.mediaQuerySize()
 
-/// Similar to MediaQuery.of(context).padding
+/// Similar to MediaQuery.paddingOf(context);
 context.mediaQueryPadding()
 
-/// Similar to MediaQuery.of(context).viewPadding
+/// Similar to MediaQuery.viewPaddingOf(context);
 context.mediaQueryViewPadding()
 
-/// Similar to MediaQuery.of(context).viewInsets;
+/// Similar to MediaQuery.viewInsetsOf(context);
 context.mediaQueryViewInsets()
 
-/// Similar to MediaQuery.of(context).orientation;
+/// Similar to MediaQuery.orientationOf(context);
 context.orientation()
 
 /// Check if device is on landscape mode
@@ -701,10 +701,10 @@ context.isLandscape()
 /// Check if device is on portrait mode
 context.isPortrait()
 
-/// Similar to MediaQuery.of(context).devicePixelRatio;
+/// Similar to MediaQuery.devicePixelRatioOf(context);
 context.devicePixelRatio()
 
-/// Similar to MediaQuery.of(context).textScaleFactor;
+/// Similar to MediaQuery.textScaleFactorOf(context);
 context.textScaleFactor()
 
 /// Get the shortestSide from screen

--- a/lib/get_utils/src/extensions/context_extensions.dart
+++ b/lib/get_utils/src/extensions/context_extensions.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
 extension ContextExt on BuildContext {
-  /// The same of [MediaQuery.of(context).size]
-  Size get mediaQuerySize => MediaQuery.of(this).size;
+  /// The same of [MediaQuery.sizeOf(context)]
+  Size get mediaQuerySize => MediaQuery.sizeOf(this);
 
   /// The same of [MediaQuery.of(context).size.height]
   /// Note: updates when you rezise your screen (like on a browser or
@@ -65,20 +65,20 @@ extension ContextExt on BuildContext {
   /// similar to [MediaQuery.of(context).padding]
   TextTheme get textTheme => Theme.of(this).textTheme;
 
-  /// similar to [MediaQuery.of(context).padding]
-  EdgeInsets get mediaQueryPadding => MediaQuery.of(this).padding;
+  /// similar to [MediaQuery.paddingOf(context)]
+  EdgeInsets get mediaQueryPadding => MediaQuery.paddingOf(this);
 
   /// similar to [MediaQuery.of(context).padding]
   MediaQueryData get mediaQuery => MediaQuery.of(this);
 
-  /// similar to [MediaQuery.of(context).viewPadding]
-  EdgeInsets get mediaQueryViewPadding => MediaQuery.of(this).viewPadding;
+  /// similar to [MediaQuery.viewPaddingOf(context)]
+  EdgeInsets get mediaQueryViewPadding => MediaQuery.viewPaddingOf(this);
 
-  /// similar to [MediaQuery.of(context).viewInsets]
-  EdgeInsets get mediaQueryViewInsets => MediaQuery.of(this).viewInsets;
+  /// similar to [MediaQuery.viewInsetsOf(context)]
+  EdgeInsets get mediaQueryViewInsets => MediaQuery.viewInsetsOf(this);
 
-  /// similar to [MediaQuery.of(context).orientation]
-  Orientation get orientation => MediaQuery.of(this).orientation;
+  /// similar to [MediaQuery.orientationOf(context)]
+  Orientation get orientation => MediaQuery.orientationOf(this);
 
   /// check if device is on landscape mode
   bool get isLandscape => orientation == Orientation.landscape;
@@ -86,11 +86,11 @@ extension ContextExt on BuildContext {
   /// check if device is on portrait mode
   bool get isPortrait => orientation == Orientation.portrait;
 
-  /// similar to [MediaQuery.of(this).devicePixelRatio]
-  double get devicePixelRatio => MediaQuery.of(this).devicePixelRatio;
+  /// similar to [MediaQuery.devicePixelRatioOf(context)]
+  double get devicePixelRatio => MediaQuery.devicePixelRatioOf(this);
 
-  /// similar to [MediaQuery.of(this).textScaleFactor]
-  double get textScaleFactor => MediaQuery.of(this).textScaleFactor;
+  /// similar to [MediaQuery.textScaleFactorOf(context)]
+  double get textScaleFactor => MediaQuery.textScaleFactorOf(this);
 
   /// get the shortestSide from screen
   double get mediaQueryShortestSide => mediaQuerySize.shortestSide;


### PR DESCRIPTION
- Migrated **MediaQuery extensions** to **InheritedModel**
- closes https://github.com/jonataslaw/getx/issues/2850

## Pre-launch Checklist

- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [X] All existing and new tests are passing.
