### PR TITLE
Make cancelAllSnackbars async

### DIFF
--- a/lib/get_navigation/src/snackbar/snackbar_controller.dart
+++ b/lib/get_navigation/src/snackbar/snackbar_controller.dart
@@ -347,8 +347,8 @@ class SnackbarController {
     return future;
   }
 
-  static void cancelAllSnackbars() {
-    _snackBarQueue._cancelAllJobs();
+  static Future<void> cancelAllSnackbars() async {
+    await _snackBarQueue._cancelAllJobs();
   }
 
   static Future<void> closeCurrentSnackbar() async {


### PR DESCRIPTION
**Title:** Make `cancelAllSnackbars` async

**Description:**

This PR changes the `cancelAllSnackbars` method in `SnackbarController` to be `async`. This allows the method to wait until all snackbars are cancelled before returning. Previously, the method returned immediately, and any errors that occurred during the cancellation of the snackbars were not caught by a `try-catch` block.

This change will help prevent `LateInitializationError` errors when trying to cancel all snackbars.