### PR TITLE
add scalable pixel and split screen width to size_percent_extension.dart

### DIFF
--- a/lib/src/responsive/size_percent_extension.dart
+++ b/lib/src/responsive/size_percent_extension.dart
@@ -6,4 +6,16 @@ extension PercentSized on double {
   double get hp => (Get.height * (this / 100));
   // width: 30.0.hp = 30%
   double get wp => (Get.width * (this / 100));
+  
+  // split width in landscape (2 half)
+  double get swp => this *  (isLandscape ? (Get.width * 0.5) : Get.width) / 100;
+
+  /// Calculates the sp (Scalable Pixel) depending on the device's screen size
+  double get sp => this * ((isLandscape ? Get.height : Get.width) / fontSizeDividedRation) / 100;
+
+  // define what a ratio that I will divided font
+  int get fontSizeDividedRation => Get.context!.isPhone ? 3 : 5;
+
+  // if landscape
+  bool get isLandscape => Get.context!.isLandscape;
 }


### PR DESCRIPTION
this PR will add:

-add scalable pixel for font example and it coding by way that keep font size scalable and fit all screens size.
-add also split screen width pixel that use in case (split screen in landscape to two side), its make items width fits this case.

I have tested it in own project in local.