### PR TITLE
switch to package:web to support wasm compilation

### DIFF
--- a/lib/get_navigation/src/routes/get_router_delegate.dart
+++ b/lib/get_navigation/src/routes/get_router_delegate.dart
@@ -612,9 +612,12 @@ class GetDelegate extends RouterDelegate<RouteDecoder>
   }) async {
     // remove history or page entries until you meet route
     var iterator = currentConfiguration;
-    while (_canPop(popMode) &&
-        iterator != null &&
-        iterator.pageSettings?.name != fullRoute) {
+    while (_canPop(popMode) && iterator != null) {
+      //the next line causes wasm compile error if included in the while loop
+      //https://github.com/flutter/flutter/issues/140110
+      if (iterator.pageSettings?.name == fullRoute) {
+        break;
+      }
       await _pop(popMode, null);
       // replace iterator
       iterator = currentConfiguration;

--- a/lib/get_navigation/src/routes/page_settings.dart
+++ b/lib/get_navigation/src/routes/page_settings.dart
@@ -40,7 +40,7 @@ extension PageArgExt on BuildContext {
   String get location {
     final parser = router.routeInformationParser;
     final config = delegate.currentConfiguration;
-    return parser?.restoreRouteInformation(config)?.location ?? '/';
+    return parser?.restoreRouteInformation(config)?.uri.toString() ?? '/';
   }
 
   GetDelegate get delegate {

--- a/lib/get_utils/src/platform/platform_web.dart
+++ b/lib/get_utils/src/platform/platform_web.dart
@@ -1,5 +1,5 @@
 // ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html;
+import 'package:web/web.dart' as html;
 
 import '../../get_utils.dart';
 
@@ -25,7 +25,7 @@ class GeneralPlatform {
   static bool get isIOS {
     // maxTouchPoints is needed to separate iPad iOS13 vs new MacOS
     return GetUtils.hasMatch(_navigator.platform, r'/iPad|iPhone|iPod/') ||
-        (_navigator.platform == 'MacIntel' && _navigator.maxTouchPoints! > 1);
+        (_navigator.platform == 'MacIntel' && _navigator.maxTouchPoints > 1);
   }
 
   static bool get isFuchsia => false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
+  web: any
 
 dev_dependencies:
   flutter_lints: ^2.0.3


### PR DESCRIPTION
Switching to package:web so that we can compile to wasm without any issues. 

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
