### PR TITLE
#2995 \ Displaying a Snackbar that is does not use the full width makes buttons on that height unclickable - Resolved

### DIFF
--- a/example_nav2/android/app/build.gradle
+++ b/example_nav2/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -35,8 +35,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.get.example_nav2"
-        minSdkVersion 16
-        targetSdkVersion 30
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example_nav2/android/app/src/main/AndroidManifest.xml
+++ b/example_nav2/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/example_nav2/android/build.gradle
+++ b/example_nav2/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.20'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -24,6 +24,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example_nav2/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example_nav2/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip

--- a/example_nav2/android/local.properties
+++ b/example_nav2/android/local.properties
@@ -1,2 +1,5 @@
-sdk.dir=C:\\Users\\anike\\AppData\\Local\\Android\\sdk
-flutter.sdk=C:\\flutter
+sdk.dir=C:\\Users\\normalguy\\AppData\\Local\\Android\\sdk
+flutter.sdk=C:\\Users\\normalguy\\Downloads\\flutter
+flutter.buildMode=debug
+flutter.versionName=1.0.0
+flutter.versionCode=1

--- a/lib/get_navigation/src/snackbar/snackbar.dart
+++ b/lib/get_navigation/src/snackbar/snackbar.dart
@@ -100,6 +100,12 @@ class GetSnackBar extends StatefulWidget {
   /// will be returned.
   final bool isDismissible;
 
+  /// Disabling the Alignment widget, this modification ensures that when a snack bar appears,
+  /// it overlays the entire screen according to its height,
+  /// making widgets in that portion inaccessible. Setting disableSelfAlignment to true disables self-alignment,
+  /// allowing access to background widgets while the snack bar is visible.
+  final bool disableSelfAlignment;
+
   /// Used to limit Snack width (usually on large screens)
   final double? maxWidth;
 
@@ -179,6 +185,7 @@ class GetSnackBar extends StatefulWidget {
     this.borderRadius = 0.0,
     this.borderColor,
     this.borderWidth = 1.0,
+    this.disableSelfAlignment = false,
     this.backgroundColor = const Color(0xFF303030),
     this.leftBarIndicatorColor,
     this.boxShadows,
@@ -186,7 +193,7 @@ class GetSnackBar extends StatefulWidget {
     this.mainButton,
     this.onTap,
     this.onHover,
-    this.duration,
+    this.duration = const Duration(milliseconds: 1500),
     this.isDismissible = true,
     this.dismissDirection,
     this.showProgressIndicator = false,
@@ -260,57 +267,64 @@ class GetSnackBarState extends State<GetSnackBar>
 
   @override
   Widget build(BuildContext context) {
-    return Align(
-      heightFactor: 1.0,
-      child: Material(
-        color: widget.snackStyle == SnackStyle.floating
-            ? Colors.transparent
-            : widget.backgroundColor,
-        child: SafeArea(
-          minimum: widget.snackPosition == SnackPosition.bottom
-              ? EdgeInsets.only(
-                  bottom: MediaQuery.of(context).viewInsets.bottom)
-              : EdgeInsets.only(top: MediaQuery.of(context).padding.top),
-          bottom: widget.snackPosition == SnackPosition.bottom,
-          top: widget.snackPosition == SnackPosition.top,
-          left: false,
-          right: false,
-          child: Stack(
-            children: [
-              FutureBuilder<Size>(
-                future: _boxHeightCompleter.future,
-                builder: (context, snapshot) {
-                  if (snapshot.hasData) {
-                    if (widget.barBlur == 0) {
-                      return _emptyWidget;
-                    }
-                    return ClipRRect(
-                      borderRadius: BorderRadius.circular(widget.borderRadius),
-                      child: BackdropFilter(
-                        filter: ImageFilter.blur(
-                            sigmaX: widget.barBlur, sigmaY: widget.barBlur),
-                        child: Container(
-                          height: snapshot.data!.height,
-                          width: snapshot.data!.width,
-                          decoration: BoxDecoration(
-                            color: Colors.transparent,
-                            borderRadius:
-                                BorderRadius.circular(widget.borderRadius),
-                          ),
-                        ),
-                      ),
-                    );
-                  } else {
+    if (widget.disableSelfAlignment) {
+      return _snackBar(context);
+    } else {
+      return Align(
+        heightFactor: 1.0,
+        child: _snackBar(context),
+      );
+    }
+  }
+
+  Material _snackBar(BuildContext context) {
+    return Material(
+      color: widget.snackStyle == SnackStyle.floating
+          ? Colors.transparent
+          : widget.backgroundColor,
+      child: SafeArea(
+        minimum: widget.snackPosition == SnackPosition.bottom
+            ? EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom)
+            : EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+        bottom: widget.snackPosition == SnackPosition.bottom,
+        top: widget.snackPosition == SnackPosition.top,
+        left: false,
+        right: false,
+        child: Stack(
+          children: [
+            FutureBuilder<Size>(
+              future: _boxHeightCompleter.future,
+              builder: (context, snapshot) {
+                if (snapshot.hasData) {
+                  if (widget.barBlur == 0) {
                     return _emptyWidget;
                   }
-                },
-              ),
-              if (widget.userInputForm != null)
-                _containerWithForm()
-              else
-                _containerWithoutForm()
-            ],
-          ),
+                  return ClipRRect(
+                    borderRadius: BorderRadius.circular(widget.borderRadius),
+                    child: BackdropFilter(
+                      filter: ImageFilter.blur(
+                          sigmaX: widget.barBlur, sigmaY: widget.barBlur),
+                      child: Container(
+                        height: snapshot.data!.height,
+                        width: snapshot.data!.width,
+                        decoration: BoxDecoration(
+                          color: Colors.transparent,
+                          borderRadius:
+                              BorderRadius.circular(widget.borderRadius),
+                        ),
+                      ),
+                    ),
+                  );
+                } else {
+                  return _emptyWidget;
+                }
+              },
+            ),
+            if (widget.userInputForm != null)
+              _containerWithForm()
+            else
+              _containerWithoutForm()
+          ],
         ),
       ),
     );


### PR DESCRIPTION
Due to the default layout, the background widgets behind it become inaccessible when the snackbar appears. Introducing an additional parameter, "disableSelfAlignment," allows users to modify the default layout to regain accessibility to the obscured widgets.

Here is a sample video.


https://github.com/jonataslaw/getx/assets/61588132/ee238864-2c3b-4689-8f1a-2fb65ac3ce26

