### PR TITLE
The default behavior for Get.defaultDialog's onCancel method should be closeAllDialogs();

### DIFF
--- a/lib/get_navigation/src/extension_navigation.dart
+++ b/lib/get_navigation/src/extension_navigation.dart
@@ -197,6 +197,7 @@ extension ExtensionDialog on GetInterface {
           ),
           onPressed: () {
             if (onCancel == null) {
+              //TODO: Close current dialog after api change
               closeAllDialogs();
             } else {
               onCancel.call();

--- a/lib/get_navigation/src/extension_navigation.dart
+++ b/lib/get_navigation/src/extension_navigation.dart
@@ -196,8 +196,11 @@ extension ExtensionDialog on GetInterface {
                 borderRadius: BorderRadius.circular(radius)),
           ),
           onPressed: () {
-            onCancel?.call();
-            back();
+            if (onCancel == null) {
+              closeAllDialogs();
+            } else {
+              onCancel.call();
+            }
           },
           child: Text(
             textCancel ?? "Cancel",


### PR DESCRIPTION
The default behavior for Get.defaultDialog's onCancel method should be closeAllDialogs();
