### PR TITLE
fixed types in equality operator

### DIFF
--- a/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
+++ b/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
@@ -100,7 +100,7 @@ mixin RxObjectMixin<T> on GetListenable<T> {
   set value(T val) {
     if (isDisposed) return;
     sentToStream = false;
-    if (value == val && !firstRebuild) return;
+    if (_value.hashCode == val.hashCode && !firstRebuild) return;
     firstRebuild = false;
     sentToStream = true;
     super.value = val;


### PR DESCRIPTION
When hashcode is not used, we can only be sure about whether primitive types have changed or not. However, for lists and maps, we need to check with hashcode.
