### PR TITLE
Solved a bug which prevented the use of base url in requests without supplying url in http requests

### DIFF
--- a/lib/get_connect/http/src/http.dart
+++ b/lib/get_connect/http/src/http.dart
@@ -90,7 +90,7 @@ class GetHttpClient {
 
   Uri createUri(String? url, Map<String, dynamic>? query) {
     if (baseUrl != null) {
-      url = baseUrl! + url!;
+      url = baseUrl! + url ?? "";
     }
     final uri = Uri.parse(url!);
     if (query != null) {


### PR DESCRIPTION
Solved a bug which prevented the use of base url in requests without supplying url in http requests especially in graphql requests where there is only one url.

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
