### PR TITLE
fix memery leak: '_routesKey' holds the reference when route poped

### DIFF
--- a/lib/get_navigation/src/router_report.dart
+++ b/lib/get_navigation/src/router_report.dart
@@ -117,6 +117,8 @@ class RouterReportManager<T> {
         _routesKey[routeName]?.remove(element);
       }
     }
+    
+    _routesKey.remove(routeName);
 
     keysToRemove.clear();
   }


### PR DESCRIPTION
When using the memory leak detection tool, I found a memory leak problem that is bound to occur: when the GetRoute is popped, the '_routeKey' reference in RouterReportManager holds the popped route's reference. So when this route is disposed, the reference object of the route should be removed from the "_routeKey" Map.

## Pre-launch Checklist
This PR is used to fix the ISSEU: https://github.com/jonataslaw/getx/issues/3138
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [ ] All existing and new tests are passing.
