### PR TITLE
[navigation] fix bug in Get.until/GetDelegate.backUntil

### DIFF
--- a/lib/get_navigation/src/routes/get_router_delegate.dart
+++ b/lib/get_navigation/src/routes/get_router_delegate.dart
@@ -627,7 +627,7 @@ class GetDelegate extends RouterDelegate<RouteDecoder>
 
   @override
   void backUntil(bool Function(GetPage) predicate) {
-    while (_activePages.length <= 1 && !predicate(_activePages.last.route!)) {
+    while (_activePages.length > 1 && !predicate(_activePages.last.route!)) {
       _popWithResult();
     }
 

--- a/test/navigation/get_main_test.dart
+++ b/test/navigation/get_main_test.dart
@@ -416,6 +416,28 @@ void main() {
     expect(find.byType(FirstScreen), findsOneWidget);
   });
 
+  testWidgets("Get.until", (tester) async {
+    await tester.pumpWidget(WrapperNamed(
+      initialRoute: '/first',
+      namedRoutes: [
+        GetPage(page: () => const FirstScreen(), name: '/first'),
+        GetPage(page: () => const SecondScreen(), name: '/second'),
+        GetPage(page: () => const ThirdScreen(), name: '/third')
+      ],
+    ));
+
+    await tester.pump();
+
+    Get.toNamed('/second');
+    await tester.pumpAndSettle();
+    Get.toNamed('/third');
+    await tester.pumpAndSettle();
+    Get.until((route) => route.name == '/first');
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FirstScreen), findsOneWidget);
+  });
+
   group("Get.defaultTransition smoke test", () {
     testWidgets("fadeIn", (tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
Right now, `backUntil` tests if there is _at most_ one route before popping. However, it should test if there is _more than one_ route.

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.

fixes #2932