### PR TITLE
Improve internationalization

### DIFF
--- a/example_nav2/lib/app/modules/dashboard/views/dashboard_view.dart
+++ b/example_nav2/lib/app/modules/dashboard/views/dashboard_view.dart
@@ -14,9 +14,9 @@ class DashboardView extends GetView<DashboardController> {
           () => Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Text(
-                'DashboardView is working',
-                style: TextStyle(fontSize: 20),
+              Text(
+                "PAGES.DASHBOARD.TITLE".tr,
+                style: const TextStyle(fontSize: 20),
               ),
               Text('Time: ${controller.now.value.toString()}'),
             ],

--- a/example_nav2/lib/lang/languages/en_US.dart
+++ b/example_nav2/lib/lang/languages/en_US.dart
@@ -1,0 +1,11 @@
+Map<String, dynamic> get enUs => {
+      "PAGES": {
+        "DASHBOARD": {
+          "TITLE": "Dashboard",
+          "BUTTONS": {
+            "CHANGE_LANGUAGE": "Change language",
+            "GO_TO_HOME": "Go to home",
+          },
+        },
+      },
+    };

--- a/example_nav2/lib/lang/languages/es_ES.dart
+++ b/example_nav2/lib/lang/languages/es_ES.dart
@@ -1,0 +1,11 @@
+Map<String, dynamic> get esEs => {
+      "PAGES": {
+        "DASHBOARD": {
+          "TITLE": "Tablero mejorado",
+          "BUTTONS": {
+            "CHANGE_LANGUAGE": "Cambiar idioma",
+            "GO_TO_HOME": "Ir a inicio",
+          },
+        },
+      },
+    };

--- a/example_nav2/lib/lang/languages/pt_BR.dart
+++ b/example_nav2/lib/lang/languages/pt_BR.dart
@@ -1,0 +1,11 @@
+Map<String, dynamic> get ptBr => {
+      "PAGES": {
+        "DASHBOARD": {
+          "TITLE": "Painel",
+          "BUTTONS": {
+            "CHANGE_LANGUAGE": "Mudar idioma",
+            "GO_TO_HOME": "Ir para casa",
+          },
+        },
+      },
+    };

--- a/example_nav2/lib/lang/translation_service.dart
+++ b/example_nav2/lib/lang/translation_service.dart
@@ -1,0 +1,19 @@
+import 'dart:ui';
+
+import 'package:example_nav2/lang/languages/en_US.dart';
+import 'package:example_nav2/lang/languages/es_ES.dart';
+import 'package:example_nav2/lang/languages/pt_BR.dart';
+import 'package:get/get.dart';
+import 'package:get/route_manager.dart';
+
+
+class TranslationService extends Translations {
+  static Locale? get locale => Get.deviceLocale;
+  static const fallbackLocale = Locale('en', 'US');
+  @override
+  Map<String, Map<String, dynamic>> get keys => {
+        'en_US': enUs,
+        'pt_BR': ptBr,
+        'es_ES': esEs,
+      };
+}

--- a/example_nav2/lib/main.dart
+++ b/example_nav2/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:example_nav2/lang/translation_service.dart';
 import 'package:example_nav2/services/auth_service.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -13,6 +14,8 @@ void main() {
       ],
       getPages: AppPages.routes,
       initialRoute: AppPages.initial,
+      translations: TranslationService(),
+      locale: TranslationService.locale,
       // builder: (context, child) {
       //   return FutureBuilder<void>(
       //     key: ValueKey('initFuture'),

--- a/lib/get_navigation/src/root/internacionalization.dart
+++ b/lib/get_navigation/src/root/internacionalization.dart
@@ -7,5 +7,5 @@ const List<String> rtlLanguages = <String>[
 ];
 
 abstract class Translations {
-  Map<String, Map<String, String>> get keys;
+  Map<String, Map<String, dynamic>> get keys;
 }

--- a/lib/get_utils/src/extensions/internacionalization.dart
+++ b/lib/get_utils/src/extensions/internacionalization.dart
@@ -33,8 +33,12 @@ extension LocalesIntl on GetInterface {
 
   Map<String, Map<String, String>> get translations => _intlHost.translations;
 
-  void addTranslations(Map<String, Map<String, String>> tr) {
-    translations.addAll(tr);
+  void addTranslations(Map<String, Map<String, dynamic>> tr) {
+    Map<String, Map<String, String>> translationsX = {};
+    tr.forEach((key, value) {
+      translationsX[key] = flattenMap(value);
+    });
+    translations.addAll(translationsX);
   }
 
   void clearTranslations() {
@@ -49,6 +53,20 @@ extension LocalesIntl on GetInterface {
         translations[key] = map;
       }
     });
+  }
+
+  Map<String, String> flattenMap(Map<String, dynamic> map,
+      [String prefix = '']) {
+    Map<String, String> flattenedMap = {};
+    map.forEach((key, value) {
+      if (value is Map) {
+        flattenedMap.addAll(flattenMap(value.cast<String, dynamic>(),
+            prefix.isEmpty ? key : '$prefix.$key'));
+      } else {
+        flattenedMap[prefix.isEmpty ? key : '$prefix.$key'] = value;
+      }
+    });
+    return flattenedMap;
   }
 }
 


### PR DESCRIPTION
This change introduces the ability to pass a Map<String, dynamic> in the translation files, enhancing the capability to organize translations into hierarchical structures, as allowed in other frameworks. This improvement provides a more flexible and structured approach to managing translations, enabling nested and complex translation keys for better organization and maintainability.

Additionally, an example of usage has been added to demonstrate how to implement this new feature. This example showcases the hierarchical organization of translation keys, making it easier to understand and utilize the enhanced translation structure.

Before: 
![image](https://github.com/user-attachments/assets/438be13f-a2d0-4cbb-8939-976362e8161d)

After:
![image](https://github.com/user-attachments/assets/ba13db8b-bd07-407f-8ba3-6a9caf3d4d5c)


