### PR TITLE
Revert supported 3.22

### DIFF
--- a/example/lib/pages/home/presentation/views/details_view.dart
+++ b/example/lib/pages/home/presentation/views/details_view.dart
@@ -23,7 +23,7 @@ class DetailsView extends GetView<DetailsController> {
           image: DecorationImage(
             fit: BoxFit.cover,
             colorFilter: ColorFilter.mode(
-              Colors.black.withValues(alpha: 0.2),
+              Colors.black.withOpacity(0.2),
               BlendMode.darken,
             ),
             image: NetworkImage(
@@ -60,8 +60,8 @@ class DetailsView extends GetView<DetailsController> {
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(25),
                   ),
-                  shadowColor: Colors.blueAccent.withValues(alpha: 0.5),
-                  color: Colors.white.withValues(alpha: 0.85),
+                  shadowColor: Colors.blueAccent.withOpacity(0.5),
+                  color: Colors.white.withOpacity(0.85),
                   child: Padding(
                     padding: const EdgeInsets.all(32.0),
                     child: Column(

--- a/example/lib/pages/home/presentation/views/home_view.dart
+++ b/example/lib/pages/home/presentation/views/home_view.dart
@@ -23,7 +23,7 @@ class HomeView extends GetView<HomeController> {
         child: BackdropFilter(
           filter: ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0),
           child: Scaffold(
-            backgroundColor: Colors.black.withValues(alpha: 0.6),
+            backgroundColor: Colors.black.withOpacity(0.6),
             extendBodyBehindAppBar: true,
             appBar: AppBar(
               title: Text(
@@ -45,14 +45,14 @@ class HomeView extends GetView<HomeController> {
                     'New Feature',
                     'Coming soon!',
                     snackPosition: SnackPosition.bottom,
-                    backgroundColor: Colors.white.withValues(alpha: 0.9),
+                    backgroundColor: Colors.white.withOpacity(0.9),
                     colorText: Colors.black,
                     borderRadius: 10,
                     duration: Duration(seconds: 3),
                     animationDuration: Duration(milliseconds: 500),
                     boxShadows: [
                       BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.2),
+                        color: Colors.black.withOpacity(0.2),
                         spreadRadius: 1,
                         blurRadius: 5,
                         offset: Offset(0, 3),
@@ -70,15 +70,14 @@ class HomeView extends GetView<HomeController> {
                     ElevatedButton(
                       style: ElevatedButton.styleFrom(
                         foregroundColor: Colors.white,
-                        backgroundColor:
-                            Colors.blueAccent.withValues(alpha: 0.8),
+                        backgroundColor: Colors.blueAccent.withOpacity(0.8),
                         padding:
                             EdgeInsets.symmetric(horizontal: 24, vertical: 16),
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(30),
                         ),
                         elevation: 8,
-                        shadowColor: Colors.blueAccent.withValues(alpha: 0.5),
+                        shadowColor: Colors.blueAccent.withOpacity(0.5),
                       ),
                       onPressed: () {
                         Get.updateLocale(Get.locale?.languageCode == 'en'
@@ -109,7 +108,7 @@ class HomeView extends GetView<HomeController> {
                                 shape: RoundedRectangleBorder(
                                   borderRadius: BorderRadius.circular(20),
                                 ),
-                                color: Colors.white.withValues(alpha: 0.9),
+                                color: Colors.white.withOpacity(0.9),
                                 child: ListTile(
                                   onTap: () async {
                                     final data = await Get.toNamed(

--- a/lib/get_animations/animations.dart
+++ b/lib/get_animations/animations.dart
@@ -373,7 +373,7 @@ class ColorAnimation extends GetAnimatedBuilder<Color?> {
   }) : super(
           builder: (context, value, child) => ColorFiltered(
             colorFilter: ColorFilter.mode(
-              Color.lerp(begin, end, value!.a.toDouble())!,
+              Color.lerp(begin, end, value?.opacity ?? 0.0)!,
               BlendMode.srcIn,
             ),
             child: child,

--- a/lib/get_navigation/src/extension_navigation.dart
+++ b/lib/get_navigation/src/extension_navigation.dart
@@ -447,7 +447,7 @@ extension ExtensionSnackbar on GetInterface {
         margin: margin ?? const EdgeInsets.symmetric(horizontal: 10),
         duration: duration,
         barBlur: barBlur ?? 7.0,
-        backgroundColor: backgroundColor ?? Colors.grey.withValues(alpha: 0.2),
+        backgroundColor: backgroundColor ?? Colors.grey.withOpacity(0.2),
         icon: icon,
         shouldIconPulse: shouldIconPulse ?? true,
         maxWidth: maxWidth,


### PR DESCRIPTION
I see in the pubspec.yaml file supported from Flutter SDK >= 3.22. But, the code just supported on Flutter SDK >= 3.29. Need to reverted then make relevan changes in the future with updated the pubspec.yaml. I think projects that use 3.29 still limited need to support for others dependencies upgrade to the latest gradle. Better to support 3.22 for now.
