### PR TITLE
Fix incorrect way of registering listener causes notifier no longer being called after disposal

### DIFF
--- a/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
+++ b/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
@@ -119,8 +119,10 @@ class GetListenable<T> extends ListNotifierSingle implements RxInterface<T> {
 
   StreamController<T> get subject {
     if (_controller == null) {
-      _controller =
-          StreamController<T>.broadcast(onCancel: addListener(_streamListener));
+      _controller = StreamController<T>.broadcast(
+        onListen: () => addListener(_streamListener),
+        onCancel: () => removeListener(_streamListener),
+      );
       _controller?.add(_value);
 
       ///TODO: report to controller dispose

--- a/test/rx/rx_workers_test.dart
+++ b/test/rx/rx_workers_test.dart
@@ -212,4 +212,23 @@ void main() {
     await Future.delayed(Duration.zero);
     expect(count, 1);
   });
+
+  test('Next "ever" after first one disposed', () async {
+    final list = [1, 2, 3].obs;
+    Future<void> register() async {
+      var count = 0;
+      final worker = ever<List<int>>(list, (value) {
+        count++;
+      });
+
+      list.add(4);
+      await Future.delayed(Duration.zero);
+      expect(count, 1);
+
+      worker.dispose();
+    }
+
+    await register();
+    await register();
+  });
 }


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

Every PR must update the corresponding documentation in the `code`, and also the readme in english with the following changes.

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
