### PR TITLE
fix-didChangeLocales

### DIFF
--- a/lib/get_navigation/src/root/get_root.dart
+++ b/lib/get_navigation/src/root/get_root.dart
@@ -459,16 +459,6 @@ class GetRootState extends State<GetRoot> with WidgetsBindingObserver {
     }
   }
 
-  @override
-  void didChangeLocales(List<Locale>? locales) {
-    Get.asap(() {
-      final locale = Get.deviceLocale;
-      if (locale != null) {
-        Get.updateLocale(locale);
-      }
-    });
-  }
-
   void setTheme(ThemeData value) {
     if (config.darkTheme == null) {
       config = config.copyWith(theme: value);


### PR DESCRIPTION
In some cases (like apps with fixed or user-selected locales), this default behavior actually causes issues — the app unintentionally switches back to the system locale after a resume or system change, even though Get.locale was manually set.

Making the locale override optional, so that developers can handle it manually if needed.

This would give us more flexibility and avoid unexpected behavior in localization-heavy apps.

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [ ] All existing and new tests are passing.
