### PR TITLE
[Fix] Duplicate existed function util and missing export

### DIFF
--- a/lib/get_connect/connect.dart
+++ b/lib/get_connect/connect.dart
@@ -9,6 +9,7 @@ export 'http/src/certificates/certificates.dart';
 export 'http/src/http.dart';
 export 'http/src/multipart/form_data.dart';
 export 'http/src/multipart/multipart_file.dart';
+export 'http/src/request/request.dart';
 export 'http/src/response/response.dart';
 export 'sockets/sockets.dart';
 

--- a/lib/get_navigation/src/routes/get_router_delegate.dart
+++ b/lib/get_navigation/src/routes/get_router_delegate.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../../../get_instance/src/bindings_interface.dart';
+import '../../../get_utils/src/extensions/iterable_extensions.dart';
 import '../../../get_utils/src/platform/platform.dart';
 import '../../../route_manager.dart';
 
@@ -280,12 +281,11 @@ class GetDelegate extends RouterDelegate<RouteDecoder>
     return SynchronousFuture(_canPopPage());
   }
 
-  bool _canPop(mode) {
+  bool _canPop(PopMode mode) {
     switch (mode) {
       case PopMode.history:
         return _canPopHistory();
       case PopMode.page:
-      default:
         return _canPopPage();
     }
   }

--- a/lib/get_navigation/src/routes/new_path_route.dart
+++ b/lib/get_navigation/src/routes/new_path_route.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/widgets.dart';
 
+import '../../../get_utils/src/extensions/iterable_extensions.dart';
 import 'get_route.dart';
 
 class RouteMatcher {
@@ -247,11 +248,3 @@ class RouteNode {
       'RouteNode(name: $path, nodeSegments: $nodeSegments, fullPath: $fullPath )';
 }
 
-extension Foo<T> on Iterable<T> {
-  T? firstWhereOrNull(bool Function(T element) test) {
-    for (var element in this) {
-      if (test(element)) return element;
-    }
-    return null;
-  }
-}

--- a/lib/get_navigation/src/routes/parse_route.dart
+++ b/lib/get_navigation/src/routes/parse_route.dart
@@ -283,13 +283,3 @@ class ParseRouteTree {
     return params;
   }
 }
-
-extension FirstWhereOrNullExt<T> on List<T> {
-  /// The first element satisfying [test], or `null` if there are none.
-  T? firstWhereOrNull(bool Function(T element) test) {
-    for (var element in this) {
-      if (test(element)) return element;
-    }
-    return null;
-  }
-}

--- a/lib/get_utils/src/extensions/export.dart
+++ b/lib/get_utils/src/extensions/export.dart
@@ -4,7 +4,7 @@ export 'duration_extensions.dart';
 export 'dynamic_extensions.dart';
 export 'event_loop_extensions.dart';
 export 'int_extensions.dart';
-export 'internacionalization.dart' hide FirstWhereExt;
+export 'internacionalization.dart';
 export 'iterable_extensions.dart';
 export 'num_extensions.dart';
 export 'string_extensions.dart';

--- a/lib/get_utils/src/extensions/internacionalization.dart
+++ b/lib/get_utils/src/extensions/internacionalization.dart
@@ -10,16 +10,6 @@ class _IntlHost {
   Map<String, Map<String, String>> translations = {};
 }
 
-extension FirstWhereExt<T> on List<T> {
-  /// The first element satisfying [test], or `null` if there are none.
-  T? firstWhereOrNull(bool Function(T element) test) {
-    for (var element in this) {
-      if (test(element)) return element;
-    }
-    return null;
-  }
-}
-
 extension LocalesIntl on GetInterface {
   static final _intlHost = _IntlHost();
 

--- a/lib/get_utils/src/extensions/iterable_extensions.dart
+++ b/lib/get_utils/src/extensions/iterable_extensions.dart
@@ -1,9 +1,18 @@
 extension IterableExtensions<T> on Iterable<T> {
   Iterable<TRes> mapMany<TRes>(
-      Iterable<TRes>? Function(T item) selector) sync* {
+    Iterable<TRes>? Function(T item) selector,
+  ) sync* {
     for (var item in this) {
       final res = selector(item);
       if (res != null) yield* res;
     }
+  }
+
+  /// The first element satisfying [test], or `null` if there are none.
+  T? firstWhereOrNull(bool Function(T element) test) {
+    for (var element in this) {
+      if (test(element)) return element;
+    }
+    return null;
   }
 }

--- a/test/utils/extensions/iterable_extensions_test.dart
+++ b/test/utils/extensions/iterable_extensions_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+
+void main() {
+  group('IterableExt', () {
+    test('firstWhereOrNull', () {
+      expect([1, 2, 3].firstWhereOrNull((e) => e == 1), equals(1));
+      expect([1, 2, 3].firstWhereOrNull((e) => e == 4), equals(null));
+    });
+  });
+}


### PR DESCRIPTION
There are 3 duplicates `firstWhereOrNull` extension util, so I decide to remove the duplicates and move to the correct location in `lib\get_utils\src\extensions\iterable_extensions.dart` to prevent from confusing and inconsistency possibility in future.

Also I added export for `lib\get_connect\http\src\request\request.dart` inside `lib\get_connect\connect.dart` for consistency of exports necessary module just like the `lib\get_connect\http\src\response\response.dart` one (it's already existed alone there).

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
