### PR TITLE
feat: update example to use Navigator 2.0

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,34 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-// import 'lang/translation_service.dart';
-// import 'routes/app_pages.dart';
-// import 'shared/logger/logger_utils.dart';
+import 'routes/app_pages.dart';
+import 'shared/logger/logger_utils.dart';
 
-// void main() {
-//   runApp(const MyApp());
-// }
-
-// class MyApp extends StatelessWidget {
-//   const MyApp({Key? key}) : super(key: key);
-
-//   @override
-//   Widget build(BuildContext context) {
-//     return GetMaterialApp(
-//       theme: ThemeData(useMaterial3: true),
-//       debugShowCheckedModeBanner: false,
-//       enableLog: true,
-//       logWriterCallback: Logger.write,
-//       initialRoute: AppPages.INITIAL,
-//       getPages: AppPages.routes,
-//       locale: TranslationService.locale,
-//       fallbackLocale: TranslationService.fallbackLocale,
-//       translations: TranslationService(),
-//     );
-//   }
-// }
-
-/// Nav 2 snippet
 void main() {
   runApp(const MyApp());
 }
@@ -38,27 +13,20 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GetMaterialApp(
-      getPages: [
-        GetPage(
-            participatesInRootNavigator: true,
-            name: '/first',
-            page: () => const First()),
-        GetPage(
-          name: '/second',
-          page: () => const Second(),
-          transition: Transition.downToUp,
-        ),
-        GetPage(
-          name: '/third',
-          page: () => const Third(),
-        ),
-        GetPage(
-          name: '/fourth',
-          page: () => const Fourth(),
-        ),
-      ],
+    return GetMaterialApp.router(
+      theme: ThemeData(useMaterial3: true),
       debugShowCheckedModeBanner: false,
+      enableLog: true,
+      logWriterCallback: Logger.write,
+      routerDelegate: GetDelegate(
+        backButtonPopMode: PopMode.History,
+        preventDuplicateHandlingMode:
+            PreventDuplicateHandlingMode.ReorderRoutes,
+      ),
+      routeInformationParser: GetInformationParser(
+        initialRoute: AppPages.INITIAL,
+      ),
+      getPages: AppPages.routes,
     );
   }
 }

--- a/example/lib/routes/app_pages.dart
+++ b/example/lib/routes/app_pages.dart
@@ -13,15 +13,15 @@ class AppPages {
 
   static final routes = [
     GetPage(
-      name: Routes.HOME,
-      page: () => const HomeView(),
-      binding: HomeBinding(),
-      children: [
-        GetPage(
-            name: Routes.DETAILS,
-            page: () => const DetailsView(),
-            binding: DetailsBinding()),
-      ],
-    ),
+        name: Routes.HOME,
+        page: () => const HomeView(),
+        binding: HomeBinding(),
+        participatesInRootNavigator: true,
+        children: [
+          GetPage(
+              name: Routes.DETAILS,
+              page: () => const DetailsView(),
+              binding: DetailsBinding()),
+        ]),
   ];
 }


### PR DESCRIPTION
This commit updates the main example to use the Navigator 2.0 API from GetX. This makes the example more modern and consistent with the `example_nav2` project.

The following changes were made:

*   `example/lib/main.dart` was updated to use `GetMaterialApp.router` with a `routerDelegate` and `routeInformationParser`.
*   The commented-out `main` function in `example/lib/main.dart` was removed.
*   `example/lib/routes/app_pages.dart` was updated to be compatible with the new navigation API.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

Every PR must update the corresponding documentation in the `code`, and also the readme in english with the following changes.

## Pre-launch Checklist

- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [ ] All existing and new tests are passing.
