### PR TITLE
Fixing the documentation for the put<S>(...) method

### DIFF
--- a/lib/get_instance/src/extension_instance.dart
+++ b/lib/get_instance/src/extension_instance.dart
@@ -53,7 +53,7 @@ extension Inst on GetInterface {
   static final Map<String, _InstanceBuilderFactory> _singl = {};
 
   /// Injects an instance `<S>` in memory to be globally accessible. Works like [find]
-  /// if the instance `<S>` already exists.
+  /// if the instance of `<S>` already exists.
   ///
   /// No need to define the generic type `<S>` as it's inferred from
   /// the [dependency]

--- a/lib/get_instance/src/extension_instance.dart
+++ b/lib/get_instance/src/extension_instance.dart
@@ -52,24 +52,17 @@ extension Inst on GetInterface {
   /// `Get.put()`
   static final Map<String, _InstanceBuilderFactory> _singl = {};
 
-  /// Holds a reference to every registered callback when using
-  /// `Get.lazyPut()`
-  // static final Map<String, _Lazy> _factory = {};
-
-  // void injector<S>(
-  //   InjectorBuilderCallback<S> fn, {
-  //   String? tag,
-  //   bool fenix = false,
-  //   //  bool permanent = false,
-  // }) {
-  //   lazyPut(
-  //     () => fn(this),
-  //     tag: tag,
-  //     fenix: fenix,
-  //     // permanent: permanent,
-  //   );
-  // }
-
+  /// Injects an instance `<S>` in memory to be globally accessible. Works like [find]
+  /// if the instance `<S>` already exists.
+  ///
+  /// No need to define the generic type `<S>` as it's inferred from
+  /// the [dependency]
+  ///
+  /// - [dependency] The Instance to be injected.
+  /// - [tag] optionally, use a [tag] as an "id" to create multiple records of
+  /// the same Type<[S]>
+  /// - [permanent] keeps the Instance in memory, not following
+  /// `Get.smartManagement` rules.
   S put<S>(
     S dependency, {
     String? tag,


### PR DESCRIPTION
This PR is fixing the documentation for the ```put<S>(...)``` method which seems to have been corrupted at some point. Adding a small note as well to say that if the instance already exists, this just works like the find method.

## Pre-launch Checklist

- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [X] All existing and new tests are passing.
