### PR TITLE
fix(get_navigation): typo “three” → “tree” in GetRoot exception (#3378)

### DIFF
--- a/lib/get_navigation/src/root/get_root.dart
+++ b/lib/get_navigation/src/root/get_root.dart
@@ -314,7 +314,7 @@ class GetRootState extends State<GetRoot> with WidgetsBindingObserver {
   static GetRootState? _controller;
   static GetRootState get controller {
     if (_controller == null) {
-      throw Exception('GetRoot is not part of the three');
+      throw Exception('GetRoot is not part of the tree');
     } else {
       return _controller!;
     }


### PR DESCRIPTION
Fixes a small typo in the GetRoot exception message: "three" -> "tree".

This is a non-behavioral change (message only). No logic affected.
References: #3378