### PR TITLE
Add support for .mov file extension in video detection

### DIFF
--- a/lib/get_utils/src/get_utils/get_utils.dart
+++ b/lib/get_utils/src/get_utils/get_utils.dart
@@ -124,7 +124,8 @@ class GetUtils {
         ext.endsWith(".rmvb") ||
         ext.endsWith(".mpg") ||
         ext.endsWith(".mpeg") ||
-        ext.endsWith(".3gp");
+        ext.endsWith(".3gp") ||
+        ext.endsWith(".mov");
   }
 
   /// Checks if string is an image file.


### PR DESCRIPTION
This PR updates the isVideo method to include support for .mov files, which are commonly used for video formats, particularly in Apple’s ecosystem. The method now checks if the file extension ends with .mov in addition to the previously supported extensions.