### PR TITLE
Allow a generic language map for each language to reduce key duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,6 @@ class Messages extends Translations {
       };
 }
 ```
-
 #### Using translations
 
 Just append `.tr` to the specified key and it will be translated, using the current value of `Get.locale` and `Get.fallbackLocale`.
@@ -425,6 +424,50 @@ return GetMaterialApp(
     locale: Get.deviceLocale,
 );
 ```
+
+#### Optimum structure for language maps
+
+In order to reduce the repition of language keys when using variants of a language you can place all the keys in a language only key-value dictionary map and then add only the keys that need to be changed to the language variant.
+
+```dart
+import 'package:get/get.dart';
+
+class Messages extends Translations {
+  @override
+  Map<String, Map<String, String>> get keys => {
+        'en': {
+          'hello': 'Hello World',
+          'netAmount': 'Net amount',
+          'tax': 'Tax'
+        },
+        'en_GB': {
+          'tax': 'VAT'
+        },
+        'en_US': {
+          'tax': 'Sales tax'
+        },
+        'de_DE': {
+          'hello': 'Hallo Welt',
+          'netAmount': 'Nettobetrag'
+          'tax': 'Steuer'
+        }
+      };
+}
+```
+
+Using the code above the translations for the keys when using different English language variants is as follows:
+
+| Locale | Key       | Translation | Dictionary map used |
+| ------ | --------- | ----------- | ------------------- |
+| en_GB  | hello     | Hello World | en                  |
+|        | netAmount | Net amount  | en                  |
+|        | tax       | VAT         | en_GB               |
+| en_US  | hello     | Hello World | en                  |
+|        | netAmount | Net amount  | en                  |
+|        | tax       | Sales tax   | en_US               |
+| en_AU  | hello     | Hello World | en                  |
+|        | netAmount | Net amount  | en                  |
+|        | tax       | Tax         | en                  |
 
 ## Change Theme
 

--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ class Messages extends Translations {
       };
 }
 ```
+
 #### Using translations
 
 Just append `.tr` to the specified key and it will be translated, using the current value of `Get.locale` and `Get.fallbackLocale`.

--- a/lib/get_utils/src/extensions/internacionalization.dart
+++ b/lib/get_utils/src/extensions/internacionalization.dart
@@ -66,6 +66,9 @@ extension Trans on String {
   // Checks if there is a callback language in the absence of the specific
   // country, and if it contains that key.
   Map<String, String>? get _getSimilarLanguageTranslation {
+    if(Get.translations.containsKey(Get.locale!.languageCode.split("_").first)){
+      return Get.translations[Get.locale!.languageCode.split("_").first];
+    }
     final translationsWithNoCountry = Get.translations
         .map((key, value) => MapEntry(key.split("_").first, value));
     final containsKey = translationsWithNoCountry

--- a/test/internationalization/internationalization_test.dart
+++ b/test/internationalization/internationalization_test.dart
@@ -12,7 +12,7 @@ void main() {
 
     await tester.pumpAndSettle();
 
-    expect('covid'.tr, 'Corona Virus');
+    expect('covid'.tr, 'Corona Virus (US totals)');
     expect('total_confirmed'.tr, 'Total Confirmed');
     expect('total_deaths'.tr, 'Total Deaths');
 
@@ -25,6 +25,22 @@ void main() {
     expect('total_deaths'.tr, 'Total de mortes');
 
     Get.updateLocale(const Locale('en', 'EN'));
+
+    await tester.pumpAndSettle();
+
+    expect('covid'.tr, 'Corona Virus');
+    expect('total_confirmed'.tr, 'Total Confirmed');
+    expect('total_deaths'.tr, 'Total Deaths');
+
+    Get.updateLocale(const Locale('en', 'GB'));
+
+    await tester.pumpAndSettle();
+
+    expect('covid'.tr, 'Corona Virus (UK totals)');
+    expect('total_confirmed'.tr, 'Total Confirmed');
+    expect('total_deaths'.tr, 'Total Deaths');
+
+    Get.updateLocale(const Locale('en', 'AU'));
 
     await tester.pumpAndSettle();
 

--- a/test/navigation/utils/wrapper.dart
+++ b/test/navigation/utils/wrapper.dart
@@ -61,10 +61,16 @@ class WrapperTranslations extends Translations {
   static Locale? get locale => const Locale('en', 'US');
   @override
   Map<String, Map<String, String>> get keys => {
-        'en_US': {
+        'en': {
           'covid': 'Corona Virus',
           'total_confirmed': 'Total Confirmed',
           'total_deaths': 'Total Deaths',
+        },
+        'en_US': {
+          'covid': 'Corona Virus (US totals)',
+        },
+        'en_GB': {
+          'covid': 'Corona Virus (UK totals)',
         },
         'pt_BR': {
           'covid': 'Corona Vírus',


### PR DESCRIPTION
Enhanced the Internationalisation so that if a key is not found in the specific country variant map (or the country variant map is not found) the first choice for the fallback is a generic language file.

e.g. If the locale is currently "en_GB" and the requested key does not exist in the "en_GB" translations map (or "en_GB" does not exist at all) then it will first look for a map with the key "en".
If that exists then this is the translation map that will be used otherwise it will use the current behaviour.
Every PR must update the corresponding documentation in the `code`, and also the readme in english with the following changes.

## Pre-launch Checklist

- [X ] I updated/added relevant documentation (doc comments with `///`).
- [X ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [X ] All existing and new tests are passing.
