### PR TITLE
Fixed issue with snackbar on flutter 3.38, for current getx v5.0.0

### DIFF
--- a/lib/get_navigation/src/snackbar/snackbar_controller.dart
+++ b/lib/get_navigation/src/snackbar/snackbar_controller.dart
@@ -92,10 +92,8 @@ class SnackbarController {
   bool _isTesting = false;
 
   void _configureOverlay() {
-    final overlayContext = Get.overlayContext;
-    _isTesting = overlayContext == null;
-    _overlayState =
-        _isTesting ? OverlayState() : Overlay.of(Get.overlayContext!);
+    _isTesting = Get.overlayContext == null;
+    _overlayState = _isTesting ? OverlayState() : Get.key.currentState?.overlay;
     _overlayEntries.clear();
     _overlayEntries.addAll(_createOverlayEntries(_getBodyWidget()));
     if (!_isTesting) {


### PR DESCRIPTION
This PR should fix: https://github.com/jonataslaw/getx/issues/3415