### PR TITLE
Added a lazy controller in GetBuilder

### DIFF
--- a/lib/get_state_manager/src/simple/get_state.dart
+++ b/lib/get_state_manager/src/simple/get_state.dart
@@ -45,6 +45,7 @@ class GetBuilder<T extends GetxController> extends StatelessWidget {
   final void Function(Binder<T> oldWidget, BindElement<T> state)?
       didUpdateWidget;
   final T? init;
+  final T Function()? controllerBuilder;
 
   const GetBuilder({
     super.key,
@@ -60,12 +61,20 @@ class GetBuilder<T extends GetxController> extends StatelessWidget {
     this.id,
     this.didChangeDependencies,
     this.didUpdateWidget,
+    this.controllerBuilder,
   });
 
   @override
   Widget build(BuildContext context) {
+     final controller = switch (init) {
+      T c => c,
+      null => switch (controllerBuilder) {
+        null => null,
+        T Function() cb => cb(),
+      },
+    };
     return Binder(
-      init: init == null ? null : () => init!,
+      init: controller == null ? null : () => controller,
       global: global,
       autoRemove: autoRemove,
       assignId: assignId,


### PR DESCRIPTION
Added a lazy controller builder in the props of GetBuilder, so that it can build its controller if need be.

#### Problem ⚠️:
```dart
class MyWidget extends StatelessWidget {
  const MyWidget({super.key});

  @override
  Widget build(BuildContext context) {
    return GetBuilder(
      // this will construct every time the widget rebuils, workaround: prop drill or Get.put()
      // This can be inconvenient if it cost a bit or widget is animated and rebuilt a lot of times
      init: MyGetController(),
      global: true,
      builder: (c) => const Placeholder(),
    );
  }
}
```
#### Solution ✅:
```dart
class MyWidget extends StatelessWidget {
  const MyWidget({super.key});

  @override
  Widget build(BuildContext context) {
    return GetBuilder(
      // This will construct once
      controllerBuilder: () => MyGetController(),
      global: true,
      builder: (c) => const Placeholder(),
    );
  }
}
```


## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
