### PR TITLE
perf: used specialized context utils

### DIFF
--- a/lib/get_animations/animations.dart
+++ b/lib/get_animations/animations.dart
@@ -44,14 +44,11 @@ class OpacityAnimation extends GetAnimatedBuilder<double> {
     required double end,
     required super.idleValue,
   }) : super(
-          tween: Tween<double>(begin: begin, end: end),
-          builder: (context, value, child) {
-            return Opacity(
-              opacity: value,
-              child: child!,
-            );
-          },
-        );
+         tween: Tween<double>(begin: begin, end: end),
+         builder: (context, value, child) {
+           return Opacity(opacity: value, child: child!);
+         },
+       );
 }
 
 class RotateAnimation extends GetAnimatedBuilder<double> {
@@ -65,12 +62,10 @@ class RotateAnimation extends GetAnimatedBuilder<double> {
     required double end,
     super.idleValue = 0,
   }) : super(
-          builder: (context, value, child) => Transform.rotate(
-            angle: value,
-            child: child,
-          ),
-          tween: Tween<double>(begin: begin, end: end),
-        );
+         builder: (context, value, child) =>
+             Transform.rotate(angle: value, child: child),
+         tween: Tween<double>(begin: begin, end: end),
+       );
 }
 
 class ScaleAnimation extends GetAnimatedBuilder<double> {
@@ -84,12 +79,10 @@ class ScaleAnimation extends GetAnimatedBuilder<double> {
     required double end,
     super.idleValue = 0,
   }) : super(
-          builder: (context, value, child) => Transform.scale(
-            scale: value,
-            child: child,
-          ),
-          tween: Tween<double>(begin: begin, end: end),
-        );
+         builder: (context, value, child) =>
+             Transform.scale(scale: value, child: child),
+         tween: Tween<double>(begin: begin, end: end),
+       );
 }
 
 // class SlideAnimation extends GetAnimatedBuilder<Offset> {
@@ -123,12 +116,10 @@ class BounceAnimation extends GetAnimatedBuilder<double> {
     required double end,
     super.idleValue = 0,
   }) : super(
-          builder: (context, value, child) => Transform.scale(
-            scale: 1 + value.abs(),
-            child: child,
-          ),
-          tween: Tween<double>(begin: begin, end: end),
-        );
+         builder: (context, value, child) =>
+             Transform.scale(scale: 1 + value.abs(), child: child),
+         tween: Tween<double>(begin: begin, end: end),
+       );
 }
 
 class SpinAnimation extends GetAnimatedBuilder<double> {
@@ -140,12 +131,10 @@ class SpinAnimation extends GetAnimatedBuilder<double> {
     super.onComplete,
     super.idleValue = 0,
   }) : super(
-          builder: (context, value, child) => Transform.rotate(
-            angle: value * pi / 180.0,
-            child: child,
-          ),
-          tween: Tween<double>(begin: 0, end: 360),
-        );
+         builder: (context, value, child) =>
+             Transform.rotate(angle: value * pi / 180.0, child: child),
+         tween: Tween<double>(begin: 0, end: 360),
+       );
 }
 
 class SizeAnimation extends GetAnimatedBuilder<double> {
@@ -159,12 +148,10 @@ class SizeAnimation extends GetAnimatedBuilder<double> {
     required double begin,
     required double end,
   }) : super(
-          builder: (context, value, child) => Transform.scale(
-            scale: value,
-            child: child,
-          ),
-          tween: Tween<double>(begin: begin, end: end),
-        );
+         builder: (context, value, child) =>
+             Transform.scale(scale: value, child: child),
+         tween: Tween<double>(begin: begin, end: end),
+       );
 }
 
 class BlurAnimation extends GetAnimatedBuilder<double> {
@@ -178,15 +165,12 @@ class BlurAnimation extends GetAnimatedBuilder<double> {
     required double end,
     super.idleValue = 0,
   }) : super(
-          builder: (context, value, child) => BackdropFilter(
-            filter: ImageFilter.blur(
-              sigmaX: value,
-              sigmaY: value,
-            ),
-            child: child,
-          ),
-          tween: Tween<double>(begin: begin, end: end),
-        );
+         builder: (context, value, child) => BackdropFilter(
+           filter: ImageFilter.blur(sigmaX: value, sigmaY: value),
+           child: child,
+         ),
+         tween: Tween<double>(begin: begin, end: end),
+       );
 }
 
 class FlipAnimation extends GetAnimatedBuilder<double> {
@@ -200,16 +184,16 @@ class FlipAnimation extends GetAnimatedBuilder<double> {
     required double end,
     super.idleValue = 0,
   }) : super(
-          builder: (context, value, child) {
-            final radians = value * pi;
-            return Transform(
-              transform: Matrix4.rotationY(radians),
-              alignment: Alignment.center,
-              child: child,
-            );
-          },
-          tween: Tween<double>(begin: begin, end: end),
-        );
+         builder: (context, value, child) {
+           final radians = value * pi;
+           return Transform(
+             transform: Matrix4.rotationY(radians),
+             alignment: Alignment.center,
+             child: child,
+           );
+         },
+         tween: Tween<double>(begin: begin, end: end),
+       );
 }
 
 class WaveAnimation extends GetAnimatedBuilder<double> {
@@ -223,16 +207,16 @@ class WaveAnimation extends GetAnimatedBuilder<double> {
     required double end,
     super.idleValue = 0,
   }) : super(
-          builder: (context, value, child) => Transform(
-            transform: Matrix4.translationValues(
-              0.0,
-              20.0 * sin(value * pi * 2),
-              0.0,
-            ),
-            child: child,
-          ),
-          tween: Tween<double>(begin: begin, end: end),
-        );
+         builder: (context, value, child) => Transform(
+           transform: Matrix4.translationValues(
+             0.0,
+             20.0 * sin(value * pi * 2),
+             0.0,
+           ),
+           child: child,
+         ),
+         tween: Tween<double>(begin: begin, end: end),
+       );
 }
 
 class WobbleAnimation extends GetAnimatedBuilder<double> {
@@ -246,15 +230,15 @@ class WobbleAnimation extends GetAnimatedBuilder<double> {
     required double end,
     super.idleValue = 0,
   }) : super(
-          builder: (context, value, child) => Transform(
-            transform: Matrix4.identity()
-              ..setEntry(3, 2, 0.001)
-              ..rotateZ(sin(value * pi * 2) * 0.1),
-            alignment: Alignment.center,
-            child: child,
-          ),
-          tween: Tween<double>(begin: begin, end: end),
-        );
+         builder: (context, value, child) => Transform(
+           transform: Matrix4.identity()
+             ..setEntry(3, 2, 0.001)
+             ..rotateZ(sin(value * pi * 2) * 0.1),
+           alignment: Alignment.center,
+           child: child,
+         ),
+         tween: Tween<double>(begin: begin, end: end),
+       );
 }
 
 class SlideInLeftAnimation extends SlideAnimation {
@@ -268,9 +252,9 @@ class SlideInLeftAnimation extends SlideAnimation {
     required super.end,
     super.idleValue = 0,
   }) : super(
-          offsetBuild: (context, value) =>
-              Offset(value * MediaQuery.of(context).size.width, 0),
-        );
+         offsetBuild: (context, value) =>
+             Offset(value * MediaQuery.sizeOf(context).width, 0),
+       );
 }
 
 class SlideInRightAnimation extends SlideAnimation {
@@ -284,9 +268,9 @@ class SlideInRightAnimation extends SlideAnimation {
     required super.end,
     super.idleValue = 0,
   }) : super(
-          offsetBuild: (context, value) =>
-              Offset((1 - value) * MediaQuery.of(context).size.width, 0),
-        );
+         offsetBuild: (context, value) =>
+             Offset((1 - value) * MediaQuery.sizeOf(context).width, 0),
+       );
 }
 
 class SlideInUpAnimation extends SlideAnimation {
@@ -300,9 +284,9 @@ class SlideInUpAnimation extends SlideAnimation {
     required super.end,
     super.idleValue = 0,
   }) : super(
-          offsetBuild: (context, value) =>
-              Offset(0, value * MediaQuery.of(context).size.height),
-        );
+         offsetBuild: (context, value) =>
+             Offset(0, value * MediaQuery.sizeOf(context).height),
+       );
 }
 
 class SlideInDownAnimation extends SlideAnimation {
@@ -316,9 +300,9 @@ class SlideInDownAnimation extends SlideAnimation {
     required super.end,
     super.idleValue = 0,
   }) : super(
-          offsetBuild: (context, value) =>
-              Offset(0, (1 - value) * MediaQuery.of(context).size.height),
-        );
+         offsetBuild: (context, value) =>
+             Offset(0, (1 - value) * MediaQuery.sizeOf(context).height),
+       );
 }
 
 class SlideAnimation extends GetAnimatedBuilder<double> {
@@ -333,12 +317,12 @@ class SlideAnimation extends GetAnimatedBuilder<double> {
     super.onComplete,
     super.idleValue = 0,
   }) : super(
-          builder: (context, value, child) => Transform.translate(
-            offset: offsetBuild(context, value),
-            child: child,
-          ),
-          tween: Tween<double>(begin: begin, end: end),
-        );
+         builder: (context, value, child) => Transform.translate(
+           offset: offsetBuild(context, value),
+           child: child,
+         ),
+         tween: Tween<double>(begin: begin, end: end),
+       );
 }
 
 // class ZoomAnimation extends GetAnimatedBuilder<double> {
@@ -371,14 +355,14 @@ class ColorAnimation extends GetAnimatedBuilder<Color?> {
     required Color end,
     Color? idleColor,
   }) : super(
-          builder: (context, value, child) => ColorFiltered(
-            colorFilter: ColorFilter.mode(
-              Color.lerp(begin, end, value!.a.toDouble())!,
-              BlendMode.srcIn,
-            ),
-            child: child,
-          ),
-          idleValue: idleColor ?? begin,
-          tween: ColorTween(begin: begin, end: end),
-        );
+         builder: (context, value, child) => ColorFiltered(
+           colorFilter: ColorFilter.mode(
+             Color.lerp(begin, end, value!.a.toDouble())!,
+             BlendMode.srcIn,
+           ),
+           child: child,
+         ),
+         idleValue: idleColor ?? begin,
+         tween: ColorTween(begin: begin, end: end),
+       );
 }

--- a/lib/get_navigation/src/bottomsheet/bottomsheet.dart
+++ b/lib/get_navigation/src/bottomsheet/bottomsheet.dart
@@ -74,16 +74,20 @@ class GetModalBottomSheetRoute<T> extends PopupRoute<T> {
   @override
   AnimationController createAnimationController() {
     assert(_animationController == null);
-    _animationController =
-        BottomSheet.createAnimationController(navigator!.overlay!);
+    _animationController = BottomSheet.createAnimationController(
+      navigator!.overlay!,
+    );
     _animationController!.duration = enterBottomSheetDuration;
     _animationController!.reverseDuration = exitBottomSheetDuration;
     return _animationController!;
   }
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> animation,
-      Animation<double> secondaryAnimation) {
+  Widget buildPage(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+  ) {
     final sheetTheme =
         theme?.bottomSheetTheme ?? Theme.of(context).bottomSheetTheme;
     // By definition, the bottom sheet is aligned to the bottom of the page
@@ -92,11 +96,13 @@ class GetModalBottomSheetRoute<T> extends PopupRoute<T> {
       context: context,
       removeTop: removeTop,
       child: Padding(
-        padding:
-            EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.viewInsetsOf(context).bottom,
+        ),
         child: _GetModalBottomSheet<T>(
           route: this,
-          backgroundColor: backgroundColor ??
+          backgroundColor:
+              backgroundColor ??
               sheetTheme.modalBackgroundColor ??
               sheetTheme.backgroundColor,
           elevation:
@@ -152,7 +158,7 @@ class _GetModalBottomSheetState<T> extends State<_GetModalBottomSheet<T>> {
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
     assert(debugCheckHasMaterialLocalizations(context));
-    final mediaQuery = MediaQuery.of(context);
+    final accessibleNavigation = MediaQuery.accessibleNavigationOf(context);
     final localizations = MaterialLocalizations.of(context);
     final routeLabel = _getRouteLabel(localizations);
 
@@ -161,7 +167,7 @@ class _GetModalBottomSheetState<T> extends State<_GetModalBottomSheet<T>> {
       builder: (context, child) {
         // Disable the initial animation when accessible navigation is on so
         // that the semantics are added to the tree at the correct time.
-        final animationValue = mediaQuery.accessibleNavigation
+        final animationValue = accessibleNavigation
             ? 1.0
             : widget.route!.animation!.value;
         return Semantics(
@@ -171,15 +177,32 @@ class _GetModalBottomSheetState<T> extends State<_GetModalBottomSheet<T>> {
           explicitChildNodes: true,
           child: ClipRect(
             child: CustomSingleChildLayout(
-                delegate: _GetModalBottomSheetLayout(
-                    animationValue, widget.isScrollControlled),
-                child: widget.isPersistent == false
-                    ? BottomSheet(
+              delegate: _GetModalBottomSheetLayout(
+                animationValue,
+                widget.isScrollControlled,
+              ),
+              child: widget.isPersistent == false
+                  ? BottomSheet(
+                      animationController: widget.route!._animationController,
+                      onClosing: () {
+                        if (widget.route!.isCurrent) {
+                          Navigator.pop(context);
+                        }
+                      },
+                      builder: widget.route!.builder!,
+                      backgroundColor: widget.backgroundColor,
+                      elevation: widget.elevation,
+                      shape: widget.shape,
+                      clipBehavior: widget.clipBehavior,
+                      enableDrag: widget.enableDrag,
+                    )
+                  : Scaffold(
+                      bottomSheet: BottomSheet(
                         animationController: widget.route!._animationController,
                         onClosing: () {
-                          if (widget.route!.isCurrent) {
-                            Navigator.pop(context);
-                          }
+                          // if (widget.route.isCurrent) {
+                          //   Navigator.pop(context);
+                          // }
                         },
                         builder: widget.route!.builder!,
                         backgroundColor: widget.backgroundColor,
@@ -187,24 +210,9 @@ class _GetModalBottomSheetState<T> extends State<_GetModalBottomSheet<T>> {
                         shape: widget.shape,
                         clipBehavior: widget.clipBehavior,
                         enableDrag: widget.enableDrag,
-                      )
-                    : Scaffold(
-                        bottomSheet: BottomSheet(
-                          animationController:
-                              widget.route!._animationController,
-                          onClosing: () {
-                            // if (widget.route.isCurrent) {
-                            //   Navigator.pop(context);
-                            // }
-                          },
-                          builder: widget.route!.builder!,
-                          backgroundColor: widget.backgroundColor,
-                          elevation: widget.elevation,
-                          shape: widget.shape,
-                          clipBehavior: widget.clipBehavior,
-                          enableDrag: widget.enableDrag,
-                        ),
-                      )),
+                      ),
+                    ),
+            ),
           ),
         );
       },
@@ -255,7 +263,7 @@ class _GetPerModalBottomSheetState<T>
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
     assert(debugCheckHasMaterialLocalizations(context));
-    final mediaQuery = MediaQuery.of(context);
+    final accessibleNavigation = MediaQuery.accessibleNavigationOf(context);
     final localizations = MaterialLocalizations.of(context);
     final routeLabel = _getRouteLabel(localizations);
 
@@ -264,7 +272,7 @@ class _GetPerModalBottomSheetState<T>
       builder: (context, child) {
         // Disable the initial animation when accessible navigation is on so
         // that the semantics are added to the tree at the correct time.
-        final animationValue = mediaQuery.accessibleNavigation
+        final animationValue = accessibleNavigation
             ? 1.0
             : widget.route!.animation!.value;
         return Semantics(
@@ -274,15 +282,32 @@ class _GetPerModalBottomSheetState<T>
           explicitChildNodes: true,
           child: ClipRect(
             child: CustomSingleChildLayout(
-                delegate: _GetModalBottomSheetLayout(
-                    animationValue, widget.isScrollControlled),
-                child: widget.isPersistent == false
-                    ? BottomSheet(
+              delegate: _GetModalBottomSheetLayout(
+                animationValue,
+                widget.isScrollControlled,
+              ),
+              child: widget.isPersistent == false
+                  ? BottomSheet(
+                      animationController: widget.route!._animationController,
+                      onClosing: () {
+                        if (widget.route!.isCurrent) {
+                          Navigator.pop(context);
+                        }
+                      },
+                      builder: widget.route!.builder!,
+                      backgroundColor: widget.backgroundColor,
+                      elevation: widget.elevation,
+                      shape: widget.shape,
+                      clipBehavior: widget.clipBehavior,
+                      enableDrag: widget.enableDrag,
+                    )
+                  : Scaffold(
+                      bottomSheet: BottomSheet(
                         animationController: widget.route!._animationController,
                         onClosing: () {
-                          if (widget.route!.isCurrent) {
-                            Navigator.pop(context);
-                          }
+                          // if (widget.route.isCurrent) {
+                          //   Navigator.pop(context);
+                          // }
                         },
                         builder: widget.route!.builder!,
                         backgroundColor: widget.backgroundColor,
@@ -290,24 +315,9 @@ class _GetPerModalBottomSheetState<T>
                         shape: widget.shape,
                         clipBehavior: widget.clipBehavior,
                         enableDrag: widget.enableDrag,
-                      )
-                    : Scaffold(
-                        bottomSheet: BottomSheet(
-                          animationController:
-                              widget.route!._animationController,
-                          onClosing: () {
-                            // if (widget.route.isCurrent) {
-                            //   Navigator.pop(context);
-                            // }
-                          },
-                          builder: widget.route!.builder!,
-                          backgroundColor: widget.backgroundColor,
-                          elevation: widget.elevation,
-                          shape: widget.shape,
-                          clipBehavior: widget.clipBehavior,
-                          enableDrag: widget.enableDrag,
-                        ),
-                      )),
+                      ),
+                    ),
+            ),
           ),
         );
       },

--- a/lib/get_navigation/src/extension_navigation.dart
+++ b/lib/get_navigation/src/extension_navigation.dart
@@ -31,32 +31,34 @@ extension ExtensionBottomSheet on GetInterface {
     Duration? exitBottomSheetDuration,
     Curve? curve,
   }) {
-    return Navigator.of(overlayContext!, rootNavigator: useRootNavigator)
-        .push(GetModalBottomSheetRoute<T>(
-      builder: (_) => bottomsheet,
-      isPersistent: persistent,
-      // theme: Theme.of(key.currentContext, shadowThemeOnly: true),
-      theme: Theme.of(key.currentContext!),
-      isScrollControlled: isScrollControlled,
+    return Navigator.of(overlayContext!, rootNavigator: useRootNavigator).push(
+      GetModalBottomSheetRoute<T>(
+        builder: (_) => bottomsheet,
+        isPersistent: persistent,
+        // theme: Theme.of(key.currentContext, shadowThemeOnly: true),
+        theme: Theme.of(key.currentContext!),
+        isScrollControlled: isScrollControlled,
 
-      barrierLabel: MaterialLocalizations.of(key.currentContext!)
-          .modalBarrierDismissLabel,
+        barrierLabel: MaterialLocalizations.of(
+          key.currentContext!,
+        ).modalBarrierDismissLabel,
 
-      backgroundColor: backgroundColor ?? Colors.transparent,
-      elevation: elevation,
-      shape: shape,
-      removeTop: ignoreSafeArea ?? true,
-      clipBehavior: clipBehavior,
-      isDismissible: isDismissible,
-      modalBarrierColor: barrierColor,
-      settings: settings,
-      enableDrag: enableDrag,
-      enterBottomSheetDuration:
-          enterBottomSheetDuration ?? const Duration(milliseconds: 250),
-      exitBottomSheetDuration:
-          exitBottomSheetDuration ?? const Duration(milliseconds: 200),
-      curve: curve,
-    ));
+        backgroundColor: backgroundColor ?? Colors.transparent,
+        elevation: elevation,
+        shape: shape,
+        removeTop: ignoreSafeArea ?? true,
+        clipBehavior: clipBehavior,
+        isDismissible: isDismissible,
+        modalBarrierColor: barrierColor,
+        settings: settings,
+        enableDrag: enableDrag,
+        enterBottomSheetDuration:
+            enterBottomSheetDuration ?? const Duration(milliseconds: 250),
+        exitBottomSheetDuration:
+            exitBottomSheetDuration ?? const Duration(milliseconds: 200),
+        curve: curve,
+      ),
+    );
   }
 }
 
@@ -85,9 +87,11 @@ extension ExtensionDialog on GetInterface {
     return generalDialog<T>(
       pageBuilder: (buildContext, animation, secondaryAnimation) {
         final pageChild = widget;
-        Widget dialog = Builder(builder: (context) {
-          return Theme(data: theme, child: pageChild);
-        });
+        Widget dialog = Builder(
+          builder: (context) {
+            return Theme(data: theme, child: pageChild);
+          },
+        );
         if (useSafeArea) {
           dialog = SafeArea(child: dialog);
         }
@@ -114,22 +118,25 @@ extension ExtensionDialog on GetInterface {
   }
 
   /// Api from showGeneralDialog with no context
-  Future<T?> generalDialog<T>(
-      {required RoutePageBuilder pageBuilder,
-      bool barrierDismissible = false,
-      String? barrierLabel,
-      Color barrierColor = const Color(0x80000000),
-      Duration transitionDuration = const Duration(milliseconds: 200),
-      RouteTransitionsBuilder? transitionBuilder,
-      GlobalKey<NavigatorState>? navigatorKey,
-      RouteSettings? routeSettings,
-      String? id}) {
+  Future<T?> generalDialog<T>({
+    required RoutePageBuilder pageBuilder,
+    bool barrierDismissible = false,
+    String? barrierLabel,
+    Color barrierColor = const Color(0x80000000),
+    Duration transitionDuration = const Duration(milliseconds: 200),
+    RouteTransitionsBuilder? transitionBuilder,
+    GlobalKey<NavigatorState>? navigatorKey,
+    RouteSettings? routeSettings,
+    String? id,
+  }) {
     assert(!barrierDismissible || barrierLabel != null);
     final key = navigatorKey ?? Get.nestedKey(id)?.navigatorKey;
-    final nav = key?.currentState ??
-        Navigator.of(overlayContext!,
-            rootNavigator:
-                true); //overlay context will always return the root navigator
+    final nav =
+        key?.currentState ??
+        Navigator.of(
+          overlayContext!,
+          rootNavigator: true,
+        ); //overlay context will always return the root navigator
     return nav.push<T>(
       GetDialogRoute<T>(
         pageBuilder: pageBuilder,
@@ -185,89 +192,105 @@ extension ExtensionDialog on GetInterface {
       actions.add(cancel);
     } else {
       if (leanCancel) {
-        actions.add(TextButton(
-          style: TextButton.styleFrom(
-            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-            shape: RoundedRectangleBorder(
+        actions.add(
+          TextButton(
+            style: TextButton.styleFrom(
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+              shape: RoundedRectangleBorder(
                 side: BorderSide(
-                    color: buttonColor ?? theme.colorScheme.secondary,
-                    width: 2,
-                    style: BorderStyle.solid),
-                borderRadius: BorderRadius.circular(radius)),
+                  color: buttonColor ?? theme.colorScheme.secondary,
+                  width: 2,
+                  style: BorderStyle.solid,
+                ),
+                borderRadius: BorderRadius.circular(radius),
+              ),
+            ),
+            onPressed: () {
+              if (onCancel == null) {
+                //TODO: Close current dialog after api change
+                closeAllDialogs();
+              } else {
+                onCancel.call();
+              }
+            },
+            child: Text(
+              textCancel ?? "Cancel",
+              style: TextStyle(
+                color: cancelTextColor ?? theme.colorScheme.secondary,
+              ),
+            ),
           ),
-          onPressed: () {
-            if (onCancel == null) {
-              //TODO: Close current dialog after api change
-              closeAllDialogs();
-            } else {
-              onCancel.call();
-            }
-          },
-          child: Text(
-            textCancel ?? "Cancel",
-            style: TextStyle(
-                color: cancelTextColor ?? theme.colorScheme.secondary),
-          ),
-        ));
+        );
       }
     }
     if (confirm != null) {
       actions.add(confirm);
     } else {
       if (leanConfirm) {
-        actions.add(TextButton(
+        actions.add(
+          TextButton(
             style: TextButton.styleFrom(
               tapTargetSize: MaterialTapTargetSize.shrinkWrap,
               backgroundColor: buttonColor ?? theme.colorScheme.secondary,
               shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(radius)),
+                borderRadius: BorderRadius.circular(radius),
+              ),
             ),
             child: Text(
               textConfirm ?? "Ok",
               style: TextStyle(
-                  color: confirmTextColor ?? theme.colorScheme.surface),
+                color: confirmTextColor ?? theme.colorScheme.surface,
+              ),
             ),
             onPressed: () {
               onConfirm?.call();
-            }));
+            },
+          ),
+        );
       }
     }
 
-    Widget baseAlertDialog = Builder(builder: (context) {
-      return AlertDialog(
-        titlePadding: titlePadding ?? const EdgeInsets.all(8),
-        contentPadding: contentPadding ?? const EdgeInsets.all(8),
+    Widget baseAlertDialog = Builder(
+      builder: (context) {
+        return AlertDialog(
+          titlePadding: titlePadding ?? const EdgeInsets.all(8),
+          contentPadding: contentPadding ?? const EdgeInsets.all(8),
 
-        backgroundColor:
-            backgroundColor ?? DialogTheme.of(context).backgroundColor,
-        shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(radius))),
-        title: Text(title, textAlign: TextAlign.center, style: titleStyle),
-        content: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            content ??
-                Text(middleText,
-                    textAlign: TextAlign.center, style: middleTextStyle),
-            const SizedBox(height: 16),
-            ButtonTheme(
-              minWidth: 78.0,
-              height: 34.0,
-              child: Wrap(
-                alignment: WrapAlignment.center,
-                spacing: 8,
-                runSpacing: 8,
-                children: actions!,
+          backgroundColor:
+              backgroundColor ?? DialogTheme.of(context).backgroundColor,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(radius)),
+          ),
+          title: Text(title, textAlign: TextAlign.center, style: titleStyle),
+          content: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              content ??
+                  Text(
+                    middleText,
+                    textAlign: TextAlign.center,
+                    style: middleTextStyle,
+                  ),
+              const SizedBox(height: 16),
+              ButtonTheme(
+                minWidth: 78.0,
+                height: 34.0,
+                child: Wrap(
+                  alignment: WrapAlignment.center,
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: actions!,
+                ),
               ),
-            )
-          ],
-        ),
-        // actions: actions, // ?? <Widget>[cancelButton, confirmButton],
-        buttonPadding: EdgeInsets.zero,
-      );
-    });
+            ],
+          ),
+          // actions: actions, // ?? <Widget>[cancelButton, confirmButton],
+          buttonPadding: EdgeInsets.zero,
+        );
+      },
+    );
 
     return dialog<T>(
       onWillPop != null
@@ -423,56 +446,59 @@ extension ExtensionSnackbar on GetInterface {
     Form? userInputForm,
   }) {
     final getSnackBar = GetSnackBar(
-        snackbarStatus: snackbarStatus,
-        titleText: titleText ??
-            Text(
-              title,
-              style: TextStyle(
-                color: colorText ?? iconColor ?? Colors.black,
-                fontWeight: FontWeight.w800,
-                fontSize: 16,
-              ),
+      snackbarStatus: snackbarStatus,
+      titleText:
+          titleText ??
+          Text(
+            title,
+            style: TextStyle(
+              color: colorText ?? iconColor ?? Colors.black,
+              fontWeight: FontWeight.w800,
+              fontSize: 16,
             ),
-        messageText: messageText ??
-            Text(
-              message,
-              style: TextStyle(
-                color: colorText ?? iconColor ?? Colors.black,
-                fontWeight: FontWeight.w300,
-                fontSize: 14,
-              ),
+          ),
+      messageText:
+          messageText ??
+          Text(
+            message,
+            style: TextStyle(
+              color: colorText ?? iconColor ?? Colors.black,
+              fontWeight: FontWeight.w300,
+              fontSize: 14,
             ),
-        snackPosition: snackPosition ?? SnackPosition.top,
-        borderRadius: borderRadius ?? 15,
-        margin: margin ?? const EdgeInsets.symmetric(horizontal: 10),
-        duration: duration,
-        barBlur: barBlur ?? 7.0,
-        backgroundColor: backgroundColor ?? Colors.grey.withValues(alpha: 0.2),
-        icon: icon,
-        shouldIconPulse: shouldIconPulse ?? true,
-        maxWidth: maxWidth,
-        padding: padding ?? const EdgeInsets.all(16),
-        borderColor: borderColor,
-        borderWidth: borderWidth,
-        leftBarIndicatorColor: leftBarIndicatorColor,
-        boxShadows: boxShadows,
-        backgroundGradient: backgroundGradient,
-        mainButton: mainButton,
-        onTap: onTap,
-        onHover: onHover,
-        isDismissible: isDismissible ?? true,
-        dismissDirection: dismissDirection,
-        showProgressIndicator: showProgressIndicator ?? false,
-        progressIndicatorController: progressIndicatorController,
-        progressIndicatorBackgroundColor: progressIndicatorBackgroundColor,
-        progressIndicatorValueColor: progressIndicatorValueColor,
-        snackStyle: snackStyle ?? SnackStyle.floating,
-        forwardAnimationCurve: forwardAnimationCurve ?? Curves.easeOutCirc,
-        reverseAnimationCurve: reverseAnimationCurve ?? Curves.easeOutCirc,
-        animationDuration: animationDuration ?? const Duration(seconds: 1),
-        overlayBlur: overlayBlur ?? 0.0,
-        overlayColor: overlayColor ?? Colors.transparent,
-        userInputForm: userInputForm);
+          ),
+      snackPosition: snackPosition ?? SnackPosition.top,
+      borderRadius: borderRadius ?? 15,
+      margin: margin ?? const EdgeInsets.symmetric(horizontal: 10),
+      duration: duration,
+      barBlur: barBlur ?? 7.0,
+      backgroundColor: backgroundColor ?? Colors.grey.withValues(alpha: 0.2),
+      icon: icon,
+      shouldIconPulse: shouldIconPulse ?? true,
+      maxWidth: maxWidth,
+      padding: padding ?? const EdgeInsets.all(16),
+      borderColor: borderColor,
+      borderWidth: borderWidth,
+      leftBarIndicatorColor: leftBarIndicatorColor,
+      boxShadows: boxShadows,
+      backgroundGradient: backgroundGradient,
+      mainButton: mainButton,
+      onTap: onTap,
+      onHover: onHover,
+      isDismissible: isDismissible ?? true,
+      dismissDirection: dismissDirection,
+      showProgressIndicator: showProgressIndicator ?? false,
+      progressIndicatorController: progressIndicatorController,
+      progressIndicatorBackgroundColor: progressIndicatorBackgroundColor,
+      progressIndicatorValueColor: progressIndicatorValueColor,
+      snackStyle: snackStyle ?? SnackStyle.floating,
+      forwardAnimationCurve: forwardAnimationCurve ?? Curves.easeOutCirc,
+      reverseAnimationCurve: reverseAnimationCurve ?? Curves.easeOutCirc,
+      animationDuration: animationDuration ?? const Duration(seconds: 1),
+      overlayBlur: overlayBlur ?? 0.0,
+      overlayColor: overlayColor ?? Colors.transparent,
+      userInputForm: userInputForm,
+    );
 
     final controller = SnackbarController(getSnackBar);
 
@@ -513,23 +539,25 @@ extension GetNavigationExt on GetInterface {
   ///
   /// By default, GetX will prevent you from push a route that you already in,
   /// if you want to push anyway, set [preventDuplicates] to false
-  Future<T?>? to<T extends Object?>(Widget Function() page,
-      {bool? opaque,
-      Transition? transition,
-      Curve? curve,
-      Duration? duration,
-      String? id,
-      String? routeName,
-      bool fullscreenDialog = false,
-      dynamic arguments,
-      List<BindingsInterface> bindings = const [],
-      bool preventDuplicates = true,
-      bool? popGesture,
-      bool showCupertinoParallax = true,
-      double Function(BuildContext context)? gestureWidth,
-      bool rebuildStack = true,
-      PreventDuplicateHandlingMode preventDuplicateHandlingMode =
-          PreventDuplicateHandlingMode.reorderRoutes}) {
+  Future<T?>? to<T extends Object?>(
+    Widget Function() page, {
+    bool? opaque,
+    Transition? transition,
+    Curve? curve,
+    Duration? duration,
+    String? id,
+    String? routeName,
+    bool fullscreenDialog = false,
+    dynamic arguments,
+    List<BindingsInterface> bindings = const [],
+    bool preventDuplicates = true,
+    bool? popGesture,
+    bool showCupertinoParallax = true,
+    double Function(BuildContext context)? gestureWidth,
+    bool rebuildStack = true,
+    PreventDuplicateHandlingMode preventDuplicateHandlingMode =
+        PreventDuplicateHandlingMode.reorderRoutes,
+  }) {
     return searchDelegate(id).to(
       page,
       opaque: opaque,
@@ -550,25 +578,25 @@ extension GetNavigationExt on GetInterface {
     );
   }
 
-//   GetPageBuilder _resolvePage(dynamic page, String method) {
-//     if (page is GetPageBuilder) {
-//       return page;
-//     } else if (page is Widget) {
-//       Get.log(
-//           '''WARNING, consider using: "Get.$method(() => Page())"
-//instead of "Get.$method(Page())".
-// Using a widget function instead of a widget fully guarantees that the widget
-//and its controllers will be removed from memory when they are no longer used.
-//       ''');
-//       return () => page;
-//     } else if (page is String) {
-//       throw '''Unexpected String,
-// use toNamed() instead''';
-//     } else {
-//       throw '''Unexpected format,
-// you can only use widgets and widget functions here''';
-//     }
-//   }
+  //   GetPageBuilder _resolvePage(dynamic page, String method) {
+  //     if (page is GetPageBuilder) {
+  //       return page;
+  //     } else if (page is Widget) {
+  //       Get.log(
+  //           '''WARNING, consider using: "Get.$method(() => Page())"
+  //instead of "Get.$method(Page())".
+  // Using a widget function instead of a widget fully guarantees that the widget
+  //and its controllers will be removed from memory when they are no longer used.
+  //       ''');
+  //       return () => page;
+  //     } else if (page is String) {
+  //       throw '''Unexpected String,
+  // use toNamed() instead''';
+  //     } else {
+  //       throw '''Unexpected format,
+  // you can only use widgets and widget functions here''';
+  //     }
+  //   }
 
   /// **Navigation.pushNamed()** shortcut.<br><br>
   ///
@@ -730,11 +758,9 @@ extension GetNavigationExt on GetInterface {
       final uri = Uri(path: page, queryParameters: parameters);
       page = uri.toString();
     }
-    return searchDelegate(id).backAndtoNamed(
-      page,
-      arguments: arguments,
-      result: result,
-    );
+    return searchDelegate(
+      id,
+    ).backAndtoNamed(page, arguments: arguments, result: result);
   }
 
   /// **Navigation.removeRoute()** shortcut.<br><br>
@@ -808,12 +834,7 @@ extension GetNavigationExt on GetInterface {
   ///
   /// It has the advantage of not needing context, so you can call
   /// from your business logic.
-  void back<T>({
-    T? result,
-    bool canPop = true,
-    int times = 1,
-    String? id,
-  }) {
+  void back<T>({T? result, bool canPop = true, int times = 1, String? id}) {
     if (times < 1) {
       times = 1;
     }
@@ -873,18 +894,14 @@ extension GetNavigationExt on GetInterface {
     }
   }
 
-  void closeAllDialogsAndBottomSheets(
-    String? id,
-  ) {
+  void closeAllDialogsAndBottomSheets(String? id) {
     // It can not be divided, because dialogs and bottomsheets can not be consecutive
     while ((isDialogOpen! && isBottomSheetOpen!)) {
       closeOverlay(id: id);
     }
   }
 
-  void closeAllDialogs({
-    String? id,
-  }) {
+  void closeAllDialogs({String? id}) {
     while ((isDialogOpen!)) {
       closeOverlay(id: id);
     }
@@ -906,16 +923,11 @@ extension GetNavigationExt on GetInterface {
   }
 
   /// Close the current overlay returning the [result], if provided
-  void closeOverlay<T>({
-    String? id,
-    T? result,
-  }) {
+  void closeOverlay<T>({String? id, T? result}) {
     searchDelegate(id).navigatorKey.currentState?.pop(result);
   }
 
-  void closeAllBottomSheets({
-    String? id,
-  }) {
+  void closeAllBottomSheets({String? id}) {
     while ((isBottomSheetOpen!)) {
       searchDelegate(id).navigatorKey.currentState?.pop();
     }
@@ -940,9 +952,12 @@ extension GetNavigationExt on GetInterface {
     String? id,
     T? result,
   }) {
-    void handleClose(bool closeCondition, Function closeAllFunction,
-        Function closeSingleFunction,
-        [bool? isOpenCondition]) {
+    void handleClose(
+      bool closeCondition,
+      Function closeAllFunction,
+      Function closeSingleFunction, [
+      bool? isOpenCondition,
+    ]) {
       if (closeCondition) {
         if (closeAll) {
           closeAllFunction();
@@ -954,8 +969,12 @@ extension GetNavigationExt on GetInterface {
 
     handleClose(closeSnackbar, closeAllSnackbars, closeCurrentSnackbar);
     handleClose(closeDialog, closeAllDialogs, closeOverlay, isDialogOpen);
-    handleClose(closeBottomSheet, closeAllBottomSheets, closeOverlay,
-        isBottomSheetOpen);
+    handleClose(
+      closeBottomSheet,
+      closeAllBottomSheets,
+      closeOverlay,
+      isBottomSheetOpen,
+    );
   }
 
   /// **Navigation.pushReplacement()** shortcut .<br><br>
@@ -1026,11 +1045,7 @@ extension GetNavigationExt on GetInterface {
     Object? arguments,
     String? id,
   ]) {
-    return searchDelegate(id).offUntil(
-      page,
-      predicate,
-      arguments,
-    );
+    return searchDelegate(id).offUntil(page, predicate, arguments);
   }
 
   ///
@@ -1296,6 +1311,15 @@ extension GetNavigationExt on GetInterface {
   /// give access to Mediaquery.of(context)
   MediaQueryData get mediaQuery => MediaQuery.of(context!);
 
+  /// give access to Mediaquery.PaddingOf(context)
+  EdgeInsets get padding => MediaQuery.paddingOf(context!);
+
+  /// give access to Mediaquery.viewInsets(context)
+  EdgeInsets get viewInsets => MediaQuery.viewInsetsOf(context!);
+
+  /// give access to Mediaquery.sizeOf(context)
+  ui.Size get sizeOf => MediaQuery.sizeOf(context!);
+
   /// Check if dark mode theme is enable
   bool get isDarkMode => (theme.brightness == Brightness.dark);
 
@@ -1309,11 +1333,11 @@ extension GetNavigationExt on GetInterface {
   /// give access to FocusScope.of(context)
   FocusNode? get focusScope => FocusManager.instance.primaryFocus;
 
-  // /// give access to Immutable MediaQuery.of(context).size.height
-  // double get height => MediaQuery.of(context).size.height;
+  // /// give access to Immutable MediaQuery.sizeOf(context).height
+  // double get height => MediaQuery.sizeOf(context).height;
 
-  // /// give access to Immutable MediaQuery.of(context).size.width
-  // double get width => MediaQuery.of(context).size.width;
+  // /// give access to Immutable MediaQuery.sizeOf(context).width
+  // double get width => MediaQuery.sizeOf(context).width;
 
   GlobalKey<NavigatorState> get key => rootController.key;
 
@@ -1388,26 +1412,28 @@ extension OverlayExt on GetInterface {
     Widget? loadingWidget,
     double opacity = .5,
   }) async {
-    final navigatorState =
-        Navigator.of(Get.overlayContext!, rootNavigator: false);
+    final navigatorState = Navigator.of(
+      Get.overlayContext!,
+      rootNavigator: false,
+    );
     final overlayState = navigatorState.overlay!;
 
-    final overlayEntryOpacity = OverlayEntry(builder: (context) {
-      return Opacity(
+    final overlayEntryOpacity = OverlayEntry(
+      builder: (context) {
+        return Opacity(
           opacity: opacity,
-          child: Container(
-            color: opacityColor,
-          ));
-    });
-    final overlayEntryLoader = OverlayEntry(builder: (context) {
-      return loadingWidget ??
-          const Center(
-              child: SizedBox(
-            height: 90,
-            width: 90,
-            child: Text('Loading...'),
-          ));
-    });
+          child: Container(color: opacityColor),
+        );
+      },
+    );
+    final overlayEntryLoader = OverlayEntry(
+      builder: (context) {
+        return loadingWidget ??
+            const Center(
+              child: SizedBox(height: 90, width: 90, child: Text('Loading...')),
+            );
+      },
+    );
     overlayState.insert(overlayEntryOpacity);
     overlayState.insert(overlayEntryLoader);
 

--- a/lib/get_navigation/src/snackbar/snackbar.dart
+++ b/lib/get_navigation/src/snackbar/snackbar.dart
@@ -7,8 +7,8 @@ import '../../../get_core/get_core.dart';
 import '../../get_navigation.dart';
 
 typedef OnTap = void Function(GetSnackBar snack);
-typedef OnHover = void Function(
-    GetSnackBar snack, SnackHoverState snackHoverState);
+typedef OnHover =
+    void Function(GetSnackBar snack, SnackHoverState snackHoverState);
 
 typedef SnackbarStatusCallback = void Function(SnackbarStatus? status);
 
@@ -276,9 +276,8 @@ class GetSnackBarState extends State<GetSnackBar>
             : widget.backgroundColor,
         child: SafeArea(
           minimum: widget.snackPosition == SnackPosition.bottom
-              ? EdgeInsets.only(
-                  bottom: MediaQuery.of(context).viewInsets.bottom)
-              : EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+              ? EdgeInsets.only(bottom: MediaQuery.viewInsetsOf(context).bottom)
+              : EdgeInsets.only(top: MediaQuery.paddingOf(context).top),
           bottom: widget.snackPosition == SnackPosition.bottom,
           top: widget.snackPosition == SnackPosition.top,
           left: false,
@@ -296,14 +295,17 @@ class GetSnackBarState extends State<GetSnackBar>
                       borderRadius: BorderRadius.circular(widget.borderRadius),
                       child: BackdropFilter(
                         filter: ImageFilter.blur(
-                            sigmaX: widget.barBlur, sigmaY: widget.barBlur),
+                          sigmaX: widget.barBlur,
+                          sigmaY: widget.barBlur,
+                        ),
                         child: Container(
                           height: snapshot.data!.height,
                           width: snapshot.data!.width,
                           decoration: BoxDecoration(
                             color: Colors.transparent,
-                            borderRadius:
-                                BorderRadius.circular(widget.borderRadius),
+                            borderRadius: BorderRadius.circular(
+                              widget.borderRadius,
+                            ),
                           ),
                         ),
                       ),
@@ -316,7 +318,7 @@ class GetSnackBarState extends State<GetSnackBar>
               if (widget.userInputForm != null)
                 _containerWithForm()
               else
-                _containerWithoutForm()
+                _containerWithoutForm(),
             ],
           ),
         ),
@@ -340,11 +342,12 @@ class GetSnackBarState extends State<GetSnackBar>
     super.initState();
 
     assert(
-        widget.userInputForm != null ||
-            ((widget.message != null && widget.message!.isNotEmpty) ||
-                widget.messageText != null),
-        '''
-You need to either use message[String], or messageText[Widget] or define a userInputForm[Form] in GetSnackbar''');
+      widget.userInputForm != null ||
+          ((widget.message != null && widget.message!.isNotEmpty) ||
+              widget.messageText != null),
+      '''
+You need to either use message[String], or messageText[Widget] or define a userInputForm[Form] in GetSnackbar''',
+    );
 
     _isTitlePresent = (widget.title != null || widget.titleText != null);
     _messageTopMargin = _isTitlePresent ? 6.0 : widget.padding.top;
@@ -383,15 +386,13 @@ You need to either use message[String], or messageText[Widget] or define a userI
   }
 
   void _configureLeftBarFuture() {
-    Engine.instance.addPostFrameCallback(
-      (_) {
-        final keyContext = _backgroundBoxKey.currentContext;
-        if (keyContext != null) {
-          final box = keyContext.findRenderObject() as RenderBox;
-          _boxHeightCompleter.complete(box.size);
-        }
-      },
-    );
+    Engine.instance.addPostFrameCallback((_) {
+      final keyContext = _backgroundBoxKey.currentContext;
+      if (keyContext != null) {
+        final box = keyContext.findRenderObject() as RenderBox;
+        _boxHeightCompleter.complete(box.size);
+      }
+    });
   }
 
   void _configureProgressIndicatorAnimation() {
@@ -400,19 +401,21 @@ You need to either use message[String], or messageText[Widget] or define a userI
       widget.progressIndicatorController!.addListener(_updateProgress);
 
       _progressAnimation = CurvedAnimation(
-          curve: Curves.linear, parent: widget.progressIndicatorController!);
+        curve: Curves.linear,
+        parent: widget.progressIndicatorController!,
+      );
     }
   }
 
   void _configurePulseAnimation() {
-    _fadeController =
-        AnimationController(vsync: this, duration: _pulseAnimationDuration);
-    _fadeAnimation = Tween(begin: _initialOpacity, end: _finalOpacity).animate(
-      CurvedAnimation(
-        parent: _fadeController!,
-        curve: Curves.linear,
-      ),
+    _fadeController = AnimationController(
+      vsync: this,
+      duration: _pulseAnimationDuration,
     );
+    _fadeAnimation = Tween(
+      begin: _initialOpacity,
+      end: _finalOpacity,
+    ).animate(CurvedAnimation(parent: _fadeController!, curve: Curves.linear));
 
     _fadeController!.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
@@ -438,15 +441,16 @@ You need to either use message[String], or messageText[Widget] or define a userI
         boxShadow: widget.boxShadows,
         borderRadius: BorderRadius.circular(widget.borderRadius),
         border: widget.borderColor != null
-            ? Border.all(
-                color: widget.borderColor!,
-                width: widget.borderWidth!,
-              )
+            ? Border.all(color: widget.borderColor!, width: widget.borderWidth!)
             : null,
       ),
       child: Padding(
         padding: const EdgeInsets.only(
-            left: 8.0, right: 8.0, bottom: 8.0, top: 16.0),
+          left: 8.0,
+          right: 8.0,
+          bottom: 8.0,
+          top: 16.0,
+        ),
         child: FocusScope(
           node: _focusNode,
           autofocus: true,
@@ -496,8 +500,9 @@ You need to either use message[String], or messageText[Widget] or define a userI
               _buildLeftBarIndicator(),
               if (_rowStyle == RowStyle.icon || _rowStyle == RowStyle.all)
                 ConstrainedBox(
-                  constraints:
-                      BoxConstraints.tightFor(width: 42.0 + iconPadding),
+                  constraints: BoxConstraints.tightFor(
+                    width: 42.0 + iconPadding,
+                  ),
                   child: _getIcon(),
                 ),
               Expanded(
@@ -513,7 +518,8 @@ You need to either use message[String], or messageText[Widget] or define a userI
                           left: left,
                           right: right,
                         ),
-                        child: widget.titleText ??
+                        child:
+                            widget.titleText ??
                             Text(
                               widget.title ?? "",
                               style: const TextStyle(
@@ -532,11 +538,14 @@ You need to either use message[String], or messageText[Widget] or define a userI
                         right: right,
                         bottom: widget.padding.bottom,
                       ),
-                      child: widget.messageText ??
+                      child:
+                          widget.messageText ??
                           Text(
                             widget.message ?? "",
                             style: const TextStyle(
-                                fontSize: 14.0, color: Colors.white),
+                              fontSize: 14.0,
+                              color: Colors.white,
+                            ),
                           ),
                     ),
                   ],
@@ -556,10 +565,7 @@ You need to either use message[String], or messageText[Widget] or define a userI
 
   Widget? _getIcon() {
     if (widget.icon != null && widget.icon is Icon && widget.shouldIconPulse) {
-      return FadeTransition(
-        opacity: _fadeAnimation,
-        child: widget.icon,
-      );
+      return FadeTransition(opacity: _fadeAnimation, child: widget.icon);
     } else if (widget.icon != null) {
       return widget.icon;
     } else {
@@ -570,12 +576,7 @@ You need to either use message[String], or messageText[Widget] or define a userI
   void _updateProgress() => setState(() {});
 }
 
-enum RowStyle {
-  icon,
-  action,
-  all,
-  none,
-}
+enum RowStyle { icon, action, all, none }
 
 /// Indicates Status of snackbar
 /// [SnackbarStatus.OPEN] Snack is fully open, [SnackbarStatus.CLOSED] Snackbar

--- a/lib/get_utils/src/extensions/context_extensions.dart
+++ b/lib/get_utils/src/extensions/context_extensions.dart
@@ -4,12 +4,12 @@ extension ContextExt on BuildContext {
   /// The same of [MediaQuery.sizeOf(context)]
   Size get mediaQuerySize => MediaQuery.sizeOf(this);
 
-  /// The same of [MediaQuery.of(context).size.height]
+  /// The same of [MediaQuery.sizeOf(context).height]
   /// Note: updates when you resize your screen (like on a browser or
   /// desktop window)
   double get height => mediaQuerySize.height;
 
-  /// The same of [MediaQuery.of(context).size.width]
+  /// The same of [MediaQuery.sizeOf(context).width]
   /// Note: updates when you resize your screen (like on a browser or
   /// desktop window)
   double get width => mediaQuerySize.width;

--- a/test/utils/extensions/context_extensions_test.dart
+++ b/test/utils/extensions/context_extensions_test.dart
@@ -11,59 +11,81 @@ void main() {
 
     final BuildContext context = tester.element(find.byType(Container));
 
-    var mediaQuery = MediaQuery.of(context);
+    final mediaQuery = MediaQuery.of(context);
     expect(mediaQuery, context.mediaQuery);
-    var mediaQuerySize = mediaQuery.size;
+
+    final mediaQuerySize = mediaQuery.size;
     expect(mediaQuerySize, context.mediaQuerySize);
-    var theme = Theme.of(context);
+
+    final theme = Theme.of(context);
     expect(theme, context.theme);
-    var textTheme = theme.textTheme;
+
+    final textTheme = theme.textTheme;
     expect(textTheme, context.textTheme);
-    var devicePixelRatio = mediaQuery.devicePixelRatio;
+
+    final devicePixelRatio = mediaQuery.devicePixelRatio;
     expect(devicePixelRatio, context.devicePixelRatio);
-    var height = mediaQuerySize.height;
+
+    final height = mediaQuerySize.height;
     expect(height, context.height);
+
     final heightTransformer =
         (mediaQuerySize.height - ((mediaQuerySize.height / 100) * 0)) / 1;
     expect(heightTransformer, context.heightTransformer());
-    var iconColor = theme.iconTheme.color;
+
+    final iconColor = theme.iconTheme.color;
     expect(iconColor, context.iconColor);
-    var isDarkMode = (theme.brightness == Brightness.dark);
+
+    final isDarkMode = (theme.brightness == Brightness.dark);
     expect(isDarkMode, context.isDarkMode);
-    var orientation = mediaQuery.orientation;
+
+    final orientation = mediaQuery.orientation;
     expect(orientation, context.orientation);
-    var isLandscape = orientation == Orientation.landscape;
+
+    final isLandscape = orientation == Orientation.landscape;
     expect(isLandscape, context.isLandscape);
-    var mediaQueryShortestSide = mediaQuerySize.shortestSide;
+
+    final mediaQueryShortestSide = mediaQuerySize.shortestSide;
     expect(mediaQueryShortestSide, context.mediaQueryShortestSide);
-    var width = mediaQuerySize.width;
+
+    final width = mediaQuerySize.width;
     expect(width, context.width);
 
-    var isLargeTabletOrWider = (width >= 720);
+    final isLargeTabletOrWider = (width >= 720);
     expect(isLargeTabletOrWider, context.isLargeTabletOrWider);
-    var isPhoneOrLess = (width < 600);
+
+    final isPhoneOrLess = (width < 600);
     expect(isPhoneOrLess, context.isPhoneOrLess);
-    var isPortrait = orientation == Orientation.portrait;
+
+    final isPortrait = orientation == Orientation.portrait;
     expect(isPortrait, context.isPortrait);
-    var isSmallTabletOrWider = (width >= 600);
+
+    final isSmallTabletOrWider = (width >= 600);
     expect(isSmallTabletOrWider, context.isSmallTabletOrWider);
-    var isTablet = isSmallTabletOrWider || isLargeTabletOrWider;
+
+    final isTablet = isSmallTabletOrWider || isLargeTabletOrWider;
     expect(isTablet, context.isSmallTabletOrWider);
-    var mediaQueryPadding = mediaQuery.padding;
+
+    final mediaQueryPadding = mediaQuery.padding;
     expect(mediaQueryPadding, context.mediaQueryPadding);
-    var mediaQueryViewInsets = mediaQuery.viewInsets;
+
+    final mediaQueryViewInsets = mediaQuery.viewInsets;
     expect(mediaQueryViewInsets, context.mediaQueryViewInsets);
-    var mediaQueryViewPadding = mediaQuery.viewPadding;
+
+    final mediaQueryViewPadding = mediaQuery.viewPadding;
     expect(mediaQueryViewPadding, context.mediaQueryViewPadding);
-    var widthTransformer =
+
+    final widthTransformer =
         (mediaQuerySize.width - ((mediaQuerySize.width / 100) * 0)) / 1;
     expect(widthTransformer, context.widthTransformer());
-    var ratio = heightTransformer / widthTransformer;
+
+    final ratio = heightTransformer / widthTransformer;
     expect(ratio, context.ratio());
 
-    var showNavbar = (width > 800);
+    final showNavbar = (width > 800);
     expect(showNavbar, context.showNavbar);
-    var textScaleFactor = mediaQuery.textScaler;
+
+    final textScaleFactor = mediaQuery.textScaler;
     expect(textScaleFactor, context.textScaleFactor);
   });
 }


### PR DESCRIPTION
#### Problem ⚠️
```dart
// This will cause rebuilds if any other component of context change like size, viewInsets, etc
MediaQuery.of(context).padding
MediaQuery.of(context).size // Idem
MediaQuery.of(context).viewInsets // Idem
```
### Solution ✅
```dart
MediaQuery.paddingOf(context).padding // listens only to padding
MediaQuery.sizeOf(context) // listens only to size
MediaQuery.viewInsetsOf(context) // listens only to viewInsets
// etc
```
## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @jonataslaw said the PR is test-exempt.
- [x] All existing and new tests are passing.
